### PR TITLE
Add a Host parser for IPv6 hosts with specified port; satisfy ip6 test

### DIFF
--- a/lib/deploy/host.rb
+++ b/lib/deploy/host.rb
@@ -8,7 +8,7 @@ module Deploy
 
     def initialize(host_string)
 
-      parsers = [SimpleHostParser, HostWithPortParser, HostWithUsernameParser, HostWithUsernameAndPortParser].select do |p|
+      parsers = [SimpleHostParser, HostWithPortParser, IPv6HostWithPortParser, HostWithUsernameParser, HostWithUsernameAndPortParser].select do |p|
         p.suitable?(host_string)
       end
 
@@ -76,6 +76,23 @@ module Deploy
 
     def hostname
       @host_string.split(':').first
+    end
+
+  end
+
+  class IPv6HostWithPortParser < SimpleHostParser
+
+    def self.suitable?(host_string)
+      host_string.match /[a-fA-F0-9:]+:\d+/
+    end
+
+    def port
+      @host_string.split(':').last.to_i
+    end
+
+    def hostname
+      @host_string.gsub!(/\[|\]/, '')
+      @host_string.split(':')[0..-2].join(':')
     end
 
   end

--- a/test/unit/test_host.rb
+++ b/test/unit/test_host.rb
@@ -36,8 +36,8 @@ module Deploy
       assert_equal 'example.com', h.hostname
     end
 
-    def test_does_not_confuse_upv6_hosts_with_port_specification
-      skip
+    def test_does_not_confuse_ipv6_hosts_with_port_specification
+      #skip
       h = Host.new '[1fff:0:a88:85a3::ac1f]:8001'
       assert_equal 8001,                    h.port
       assert_equal '1fff:0:a88:85a3::ac1f', h.hostname


### PR DESCRIPTION
Makes skipped test pass, may need improvement though.
