### PR TITLE
Syntax error in backends/netssh.rb

### DIFF
--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -11,13 +11,13 @@ module SSHKit
         @output = output
       end
       def debug(args)
-        output << LogMessage.new(Logger::TRACE, args))
+        output << LogMessage.new(Logger::TRACE, args)
       end
       def error(args)
-        output << LogMessage.new(Logger::ERROR, args))
+        output << LogMessage.new(Logger::ERROR, args)
       end
       def lwarn(args)
-        output << LogMessage.new(Logger::WARN, args))
+        output << LogMessage.new(Logger::WARN, args)
       end
     end
 


### PR DESCRIPTION
Fix syntax error (remove brackets) in lib/sshkit/backends/netssh.rb
