### PR TITLE
allow set ssh options for sshkit backend

### DIFF
--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -29,6 +29,11 @@ module SSHKit
 
       class Configuration
         attr_accessor :connection_timeout, :pty
+        attr_writer :ssh_options
+
+        def ssh_options
+          @ssh_options || {}
+        end
       end
 
       include SSHKit::CommandHelper
@@ -147,6 +152,7 @@ module SSHKit
 
       def ssh
         @ssh ||= begin
+          host.ssh_options ||= Netssh.config.ssh_options
           Net::SSH.start(
             String(host.hostname),
             host.username,

--- a/lib/sshkit/host.rb
+++ b/lib/sshkit/host.rb
@@ -6,7 +6,7 @@ module SSHKit
 
   class Host
 
-    attr_accessor :password, :hostname, :port, :user
+    attr_accessor :password, :hostname, :port, :user, :ssh_options
 
     def key=(new_key)
       @keys = [new_key]
@@ -78,6 +78,7 @@ module SSHKit
         sho[:password]      = password if password
         sho[:forward_agent] = true
       end
+      .merge(ssh_options || {})
     end
 
     def properties

--- a/test/unit/backends/test_netssh.rb
+++ b/test/unit/backends/test_netssh.rb
@@ -12,10 +12,20 @@ module SSHKit
         backend.configure do |ssh|
           ssh.pty = true
           ssh.connection_timeout = 30
+          ssh.connection_timeout = 30
+          ssh.ssh_options = {
+            keys: %w(/home/user/.ssh/id_rsa),
+            forward_agent: false,
+            auth_methods: %w(publickey password)
+          }
         end
 
         assert_equal 30, backend.config.connection_timeout
         assert_equal true, backend.config.pty
+
+        assert_equal %w(/home/user/.ssh/id_rsa),  backend.config.ssh_options[:keys]
+        assert_equal false,                       backend.config.ssh_options[:forward_agent]
+        assert_equal %w(publickey password),      backend.config.ssh_options[:auth_methods]
       end
     end
   end

--- a/test/unit/test_host.rb
+++ b/test/unit/test_host.rb
@@ -104,6 +104,27 @@ module SSHKit
       end
     end
 
+    def test_turning_a_host_into_ssh_options_when_extra_options_are_set
+      ssh_options = {
+        port: 3232,
+        keys: %w(/home/user/.ssh/id_rsa),
+        forward_agent: false,
+        auth_methods: %w(publickey password)
+      }
+      Host.new('someuser@example.com:2222').tap do |host|
+        host.password = "andthisdoesntevenmakeanysense"
+        host.keys     = ["~/.ssh/some_key_here"]
+        host.ssh_options = ssh_options
+        host.netssh_options.tap do |sho|
+          assert_equal 3232,                             sho.fetch(:port)
+          assert_equal 'andthisdoesntevenmakeanysense',  sho.fetch(:password)
+          assert_equal %w(/home/user/.ssh/id_rsa),       sho.fetch(:keys)
+          assert_equal false,                            sho.fetch(:forward_agent)
+          assert_equal %w(publickey password),           sho.fetch(:auth_methods)
+        end
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
you can pass shh options for backend eg

```
  SSHKit.configure do |sshkit|
     sshkit.backend.configure do |backend|
        backend.ssh_options = {
           keys: %w(/home/user/.ssh/id_rsa),
           forward_agent: false,
           auth_methods: %w(publickey password)
        }
     end
  end
```
