### PR TITLE
Match Netssh backend interface in Printer backend

### DIFF
--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -112,6 +112,16 @@ module SSHKit
         remove_instance_variable(:@group)
       end
 
+      class << self
+        def config
+          @config ||= OpenStruct.new
+        end
+
+        def configure
+          yield config
+        end
+      end
+
       private
 
       def command(*args)

--- a/lib/sshkit/backends/printer.rb
+++ b/lib/sshkit/backends/printer.rb
@@ -10,12 +10,20 @@ module SSHKit
       end
 
       def execute(*args)
-        output << command(*args).to_command + "\n"
+        command(*args).tap do |cmd|
+          output << cmd
+        end
       end
+      alias :upload! :execute
+      alias :download! :execute
+      alias :test :execute
+      alias :invoke :execute
 
-      def capture(command, args=[])
-        raise MethodUnavailableError
+      def capture(*args)
+        String.new.tap { execute(*args) }
       end
+      alias :capture! :capture
+
 
       private
 

--- a/test/unit/backends/test_printer.rb
+++ b/test/unit/backends/test_printer.rb
@@ -8,17 +8,7 @@ module SSHKit
 
       def block_to_run
         lambda do |host|
-          within '/opt/sites/example.com' do
-            execute 'date'
-            execute :ls, '-l', '/some/directory'
-            with rails_env: :production do
-              within :tmp do
-                as :root do
-                  execute :touch, 'restart.txt'
-                end
-              end
-            end
-          end
+          execute :ls, '-l', '/some/directory'
         end
       end
 
@@ -26,19 +16,17 @@ module SSHKit
         Printer.new(Host.new(:'example.com'), &block_to_run)
       end
 
+      def setup
+        SSHKit.config.output_verbosity = :debug
+      end
+
       def test_simple_printing
-        result = String.new
+        result = StringIO.new
         SSHKit.capture_output(result) do
           printer.run
         end
-        assert_equal <<-EOEXPECTED.unindent, result
-          if test ! -d /opt/sites/example.com; then echo "Directory does not exist '/opt/sites/example.com'" 1>&2; false; fi
-          cd /opt/sites/example.com && /usr/bin/env date
-          cd /opt/sites/example.com && /usr/bin/env ls -l /some/directory
-          if test ! -d /opt/sites/example.com/tmp; then echo "Directory does not exist '/opt/sites/example.com/tmp'" 1>&2; false; fi
-          if ! sudo su root -c whoami > /dev/null; then echo "You cannot switch to user 'root' using sudo, please check the sudoers file" 1>&2; false; fi
-          cd /opt/sites/example.com/tmp && ( RAILS_ENV=production sudo su root -c \"/usr/bin/env touch restart.txt\" )
-        EOEXPECTED
+        result.rewind
+        assert_equal '/usr/bin/env ls -l /some/directory', result.read
       end
 
     end


### PR DESCRIPTION
This allows Capistrano to implement `--dry-run` functionality.
