### PR TITLE
Updated gem runtime dependencies for net-scp to use 1.1.2

### DIFF
--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SSHKit::VERSION
 
-  gem.add_dependency('net-ssh')
-  gem.add_dependency('net-scp')
-  gem.add_dependency('term-ansicolor')
+  gem.add_runtime_dependency('net-ssh')
+  gem.add_runtime_dependency('net-scp', '>= 1.1.2')
+  gem.add_runtime_dependency('term-ansicolor')
 
   gem.add_development_dependency('minitest', ['>= 2.11.3', '< 2.12.0'])
   gem.add_development_dependency('rake')


### PR DESCRIPTION
I have trouble to use `remote_file` and the `net-scp-1.1.1` 

``` ruby
namespace :deploy do
  namespace :check do
    task :linked_files => 'config/database.yml'
  end
end

remote_file 'config/database.yml' => '/tmp/database.yml', roles: :all

file '/tmp/database.yml' do |t|
  sh "touch #{t.name}"
end
```

I got the next:

```
** Execute config/database.yml
DEBUG [a30c6623] Running [ -f /data/apps/application/shared/config/database.yml ] on 50.116.35.193
DEBUG [a30c6623] Command: [ -f /data/apps/application/shared/config/database.yml ]
DEBUG [a30c6623] Finished in 3.188 seconds command failed.
 INFO Uploading /tmp/database.yml to /data/apps/application/shared/config/database.yml
"start_command"
cap aborted!
undefined method `empty?' for #<Pathname:/data/apps/application/shared/config/database.yml>
.../gems/net-scp-1.1.1/lib/net/scp.rb:417:in `shellescape'
.../gems/net-scp-1.1.1/lib/net/scp.rb:347:in `block in start_command'
.../gems/net-ssh-2.6.7/lib/net/ssh/connection/channel.rb:513:in `call'
.../gems/net-ssh-2.6.7/lib/net/ssh/connection/channel.rb:513:in `do_open_confirmation'
.../gems/net-ssh-2.6.7/lib/net/ssh/connection/session.rb:539:in `channel_open_confirmation'
.../gems/net-ssh-2.6.7/lib/net/ssh/connection/session.rb:459:in `dispatch_incoming_packets'
.../gems/net-ssh-2.6.7/lib/net/ssh/connection/session.rb:216:in `preprocess'
.../gems/net-ssh-2.6.7/lib/net/ssh/connection/session.rb:200:in `process'
.../gems/net-ssh-2.6.7/lib/net/ssh/connection/session.rb:164:in `block in loop'
.../gems/net-ssh-2.6.7/lib/net/ssh/connection/session.rb:164:in `loop'
.../gems/net-ssh-2.6.7/lib/net/ssh/connection/session.rb:164:in `loop'
.../gems/net-ssh-2.6.7/lib/net/ssh/connection/channel.rb:269:in `wait'
.../gems/net-scp-1.1.1/lib/net/scp.rb:279:in `upload!'
/Volumes/Storage.../bundler/gems/sshkit-6e939dd597df/lib/sshkit/backends/netssh.rb:68:in `upload!'
.../bundler/gems/capistrano-78eb033290f7/lib/capistrano/dsl/task_enhancements.rb:28:in `block (2 levels) in define_remote_file_task'
/Volumes/Storage.../bundler/gems/sshkit-6e939dd597df/lib/sshkit/backends/netssh.rb:42:in `instance_exec'
/Volumes/Storage.../bundler/gems/sshkit-6e939dd597df/lib/sshkit/backends/netssh.rb:42:in `run'
/Volumes/Storage.../bundler/gems/sshkit-6e939dd597df/lib/sshkit/runners/parallel.rb:12:in `block (2 levels) in execute'
Tasks: TOP => deploy:check:linked_files => config/database.yml
```

Solution is update the `net-scp` to at least 1.1.2 version.

May be this PR is not required. at least someone would find solution to fix same issue.
