### PR TITLE
Log command exit status

### DIFF
--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -44,7 +44,7 @@ module SSHKit
         end
 
         if command.finished?
-          original_output << level(command.verbosity) + uuid(command) + "Finished in #{sprintf('%5.3f seconds', command.runtime)} command #{c.bold { command.failure? ? c.red('failed') : c.green('successful') }}.\n"
+          original_output << level(command.verbosity) + uuid(command) + "Finished in #{sprintf('%5.3f seconds', command.runtime)} with exit status #{command.exit_status} (#{c.bold { command.failure? ? c.red('failed') : c.green('successful') }}).\n"
         end
       end
 


### PR DESCRIPTION
Some Capistrano users were confused about such messages:

```
DEBUG [247d7a19] Command: [ -f /projects/myproject/releases/20131017094531/config/database.yml ]
DEBUG [247d7a19] Finished in 0.114 seconds command failed.
```

And asked me if it's fine when 'command failed'

With this change users will see the exit status of command.
