### PR TITLE
Making logging plain, for capturing output without all the escape codes

### DIFF
--- a/lib/sshkit/all.rb
+++ b/lib/sshkit/all.rb
@@ -14,6 +14,7 @@ require_relative 'formatters/abstract'
 require_relative 'formatters/black_hole'
 require_relative 'formatters/pretty'
 require_relative 'formatters/dot'
+require_relative 'formatters/plain'
 
 require_relative 'runners/abstract'
 require_relative 'runners/sequential'

--- a/lib/sshkit/formatters/plain.rb
+++ b/lib/sshkit/formatters/plain.rb
@@ -1,0 +1,69 @@
+module SSHKit
+
+  module Formatter
+
+    class Plain < Abstract
+
+      def write(obj)
+        return if obj.verbosity < SSHKit.config.output_verbosity
+        case obj
+        when SSHKit::Command    then write_command(obj)
+        when SSHKit::LogMessage then write_log_message(obj)
+        else
+          original_output << "Output formatter doesn't know how to handle #{obj.class}\n"
+        end
+      end
+      alias :<< :write
+
+      private
+
+      def write_command(command)
+        unless command.started?
+          original_output << level(command.verbosity) + uuid(command) + "Running #{String(command)} on #{command.host.to_s}\n"
+          if SSHKit.config.output_verbosity == Logger::DEBUG
+            original_output << level(Logger::DEBUG) + uuid(command) + "Command: #{command.to_command}" + "\n"
+          end
+        end
+
+        if SSHKit.config.output_verbosity == Logger::DEBUG
+          unless command.stdout.empty?
+            command.stdout.lines.each do |line|
+              original_output << level(Logger::DEBUG) + uuid(command) + "\t" + line
+              original_output << "\n" unless line[-1] == "\n"
+            end
+          end
+
+          unless command.stderr.empty?
+            command.stderr.lines.each do |line|
+              original_output << level(Logger::DEBUG) + uuid(command) + "\t" + line
+              original_output << "\n" unless line[-1] == "\n"
+            end
+          end
+        end
+
+        if command.finished?
+          original_output << level(command.verbosity) + uuid(command) + "Finished in #{sprintf('%5.3f seconds', command.runtime)} with exit status #{command.exit_status} (#{  command.failure? ? 'failed' : 'successful' }).\n"
+        end
+      end
+
+      def write_log_message(log_message)
+        original_output << level(log_message.verbosity) + log_message.to_s + "\n"
+      end
+
+      def uuid(obj)
+        "[#{obj.uuid}] "
+      end
+
+      def level(verbosity)
+        "[" << level_names(verbosity) << "] "
+      end
+
+      def level_names(level_num)
+        %w{ DEBUG INFO WARN ERROR FATAL }[level_num]
+      end
+
+    end
+
+  end
+
+end

--- a/test/unit/formatters/test_plain.rb
+++ b/test/unit/formatters/test_plain.rb
@@ -1,0 +1,51 @@
+require 'helper'
+require 'sshkit'
+
+module SSHKit
+  class TestPlain < UnitTest
+
+    def setup
+      SSHKit.config.output_verbosity = Logger::DEBUG
+    end
+
+    def output
+      @_output ||= String.new
+    end
+
+    def plain
+      @_plain ||= SSHKit::Formatter::Plain.new(output)
+    end
+
+    def teardown
+      remove_instance_variable :@_plain
+      remove_instance_variable :@_output
+      SSHKit.reset_configuration!
+    end
+
+    def test_logging_fatal
+      plain << SSHKit::LogMessage.new(Logger::FATAL, "Test")
+      assert_equal output.strip, "[FATAL] Test \n".strip
+    end
+
+    def test_logging_error
+      plain << SSHKit::LogMessage.new(Logger::ERROR, "Test")
+      assert_equal output.strip, "[ERROR] Test \n".strip
+    end
+
+    def test_logging_warn
+      plain << SSHKit::LogMessage.new(Logger::WARN, "Test")
+      assert_equal output.strip, "[WARN] Test \n".strip
+    end
+
+    def test_logging_info
+      plain << SSHKit::LogMessage.new(Logger::INFO, "Test")
+      assert_equal output.strip, "[INFO] Test \n".strip
+    end
+
+    def test_logging_debug
+      plain << SSHKit::LogMessage.new(Logger::DEBUG, "Test")
+      assert_equal output.strip, "[DEBUG] Test \n".strip
+    end
+
+  end
+end


### PR DESCRIPTION
For those times when you don't have full featured terminal and just want plain output (for storing in text file, or db, for later review)  This introduces a Plain formatter, that just strips out all the Escape codes..  
