### PR TITLE
Better error output

### DIFF
--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -120,8 +120,6 @@ module SSHKit
                 output << cmd
               end
               chan.on_request("exit-status") do |ch, data|
-                cmd.stdout = ''
-                cmd.stderr = ''
                 cmd.exit_status = data.read_long
                 output << cmd
               end

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -88,7 +88,7 @@ module SSHKit
       @finished_at = Time.now
       @exit_status = new_exit_status
       if options[:raise_on_non_zero_exit] && exit_status > 0
-        message = ""
+        message = "\n"
         message += "#{command} stdout: " + (stdout.strip.empty? ? "Nothing written" : stdout.strip) + "\n"
         message += "#{command} stderr: " + (stderr.strip.empty? ? "Nothing written" : stderr.strip) + "\n"
         raise Failed, message


### PR DESCRIPTION
When a remote command fails (in my case chef-solo) the stdout and stderr were being erased and thus not being included in the error message raised by sshkit. If I didn't have debug level output enabled important information was being swallowed. This changes allows stdout and stderr to pass through to the ruby exception's message.

Also, add another newline to make the output of each pipe stacked and easier to read:

```
<command> stdout: <message>
<command> stderr: <message>
```
