### PR TITLE
Improved command map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file is written in reverse chronological order, newer releases will
 appear at the top.
 
+## 1.1.0 (not released yet)
+
+  * Improved command map with prefix feature
+
 ## 1.0.0
 
   * The gem now supports a run_locally, although it's nothing to do with SSH,

--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ One can override the hash map for individual commands:
     puts SSHKit.config.command_map[:rake]
     # => /usr/local/rbenv/shims/rake
 
+Another oportunity is to add command prefixes:
+
+    SSHKit.config.command_map.prefix[:rake].push("bundle exec")
+    puts SSHKit.config.command_map[:rake]
+    # => bundle exec rake
+
+    SSHKit.config.command_map.prefix[:rake].unshift("/usr/local/rbenv/bin exec")
+    puts SSHKit.config.command_map[:rake]
+    # => /usr/local/rbenv/bin exec bundle exec rake
+
 One can also override the command map completely, this may not be wise, but it
 would be possible, for example:
 

--- a/lib/sshkit/all.rb
+++ b/lib/sshkit/all.rb
@@ -4,6 +4,7 @@ require_relative '../core_ext/hash'
 require_relative 'host'
 
 require_relative 'command'
+require_relative 'command_map'
 require_relative 'configuration'
 require_relative 'coordinator'
 

--- a/lib/sshkit/command_map.rb
+++ b/lib/sshkit/command_map.rb
@@ -1,0 +1,51 @@
+module SSHKit
+  class CommandMap
+    class PrefixProvider
+      def initialize
+        @storage = {}
+      end
+
+      def [](command)
+        @storage[command] ||= []
+
+        @storage[command]
+      end
+    end
+
+    def initialize(value = nil)
+      @map = value || defaults
+    end
+
+    def [](command)
+      if prefix[command].any?
+        prefixes = prefix[command].join(" ")
+
+        "#{prefixes} #{command}"
+      else
+        @map[command]
+      end
+    end
+
+    def prefix
+      @prefix ||= PrefixProvider.new
+    end
+
+    def []=(command, new_command)
+      @map[command] = new_command
+    end
+
+    def clear
+      @map = defaults
+    end
+
+    def defaults
+      Hash.new do |hash, command|
+        if %w{if test time}.include? command.to_s
+          hash[command] = command.to_s
+        else
+          hash[command] = "/usr/bin/env #{command}"
+        end
+      end
+    end
+  end
+end

--- a/lib/sshkit/configuration.rb
+++ b/lib/sshkit/configuration.rb
@@ -3,7 +3,7 @@ module SSHKit
   class Configuration
 
     attr_accessor :umask, :output_verbosity
-    attr_writer :output, :backend, :default_env, :command_map
+    attr_writer :output, :backend, :default_env
 
     def output
       @output ||= formatter(:pretty)
@@ -30,15 +30,11 @@ module SSHKit
     end
 
     def command_map
-      @command_map ||= begin
-        Hash.new do |hash, command|
-          if %w{if test time}.include? command.to_s
-            hash[command] = command.to_s
-          else
-            hash[command] = "/usr/bin/env #{command}"
-          end
-        end
-      end
+      @command_map ||= SSHKit::CommandMap.new
+    end
+
+    def command_map=(value)
+      @command_map = SSHKit::CommandMap.new(value)
     end
 
     private

--- a/test/unit/test_command_map.rb
+++ b/test/unit/test_command_map.rb
@@ -1,0 +1,40 @@
+require 'helper'
+require 'sshkit'
+
+module SSHKit
+  class TestCommandMap < UnitTest
+
+    def setup
+      SSHKit.reset_configuration!
+    end
+
+    def test_defaults
+      map = CommandMap.new
+      assert_equal map[:rake], "/usr/bin/env rake"
+      assert_equal map[:test], "test"
+    end
+
+    def test_setter
+      map = CommandMap.new
+      map[:rake] = "/usr/local/rbenv/shims/rake"
+      assert_equal map[:rake], "/usr/local/rbenv/shims/rake"
+    end
+
+    def test_prefix
+      map = CommandMap.new
+      map.prefix[:rake].push("/home/vagrant/.rbenv/bin/rbenv exec")
+      map.prefix[:rake].push("bundle exec")
+
+      assert_equal map[:rake], "/home/vagrant/.rbenv/bin/rbenv exec bundle exec rake"
+    end
+
+    def test_prefix_unshift
+      map = CommandMap.new
+      map.prefix[:rake].push("bundle exec")
+      map.prefix[:rake].unshift("/home/vagrant/.rbenv/bin/rbenv exec")
+
+      assert_equal map[:rake], "/home/vagrant/.rbenv/bin/rbenv exec bundle exec rake"
+    end
+
+  end
+end

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -42,11 +42,12 @@ module SSHKit
     end
 
     def test_command_map
+      assert_equal SSHKit.config.command_map.is_a?(SSHKit::CommandMap), true
+
       cm = Hash.new { |h,k| h[k] = "/opt/sites/example/current/bin #{k}"}
-      assert_equal Hash.new, SSHKit.config.command_map
-      assert_equal "/usr/bin/env ruby", SSHKit.config.command_map[:ruby]
+
       assert SSHKit.config.command_map = cm
-      assert_equal cm, SSHKit.config.command_map
+      assert_equal SSHKit.config.command_map.is_a?(SSHKit::CommandMap), true
       assert_equal "/opt/sites/example/current/bin ruby", SSHKit.config.command_map[:ruby]
     end
 


### PR DESCRIPTION
As I wrote in https://github.com/capistrano/capistrano/issues/639, we need more ways to configure command map behaviour.

This PR adds prefixes feature.
