### PR TITLE
Fix behavior of helpers in run_locally block

### DIFF
--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -13,8 +13,21 @@ module SSHKit
         instance_exec(&@block)
       end
 
+      def test(*args)
+        options = args.extract_options!.merge(
+          raise_on_non_zero_exit: false,
+          verbosity: Logger::DEBUG
+        )
+        _execute(*[*args, options]).success?
+      end
+
       def execute(*args)
         _execute(*args).success?
+      end
+
+      def capture(*args)
+        options = args.extract_options!.merge(verbosity: Logger::DEBUG)
+        _execute(*[*args, options]).full_stdout.strip
       end
 
       private


### PR DESCRIPTION
It is comfusing that call to `test()` and `capture()` helper methods in `run_locally` block behave differently from that in `on` block.
