### PR TITLE
Add test() and capture() helpers to Local class

### DIFF
--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -13,7 +13,26 @@ module SSHKit
         instance_exec(&@block)
       end
 
+      def test(*args)
+        options = args.extract_options!.merge(
+          raise_on_non_zero_exit: false,
+          verbosity: Logger::DEBUG
+        )
+        _execute(*[*args, options]).success?
+      end
+
       def execute(*args)
+        _execute(*args).success?
+      end
+
+      def capture(*args)
+        options = args.extract_options!.merge(verbosity: Logger::DEBUG)
+        _execute(*[*args, options]).full_stdout.strip
+      end
+
+      private
+
+      def _execute(*args)
         command(*args).tap do |cmd|
           output << cmd
 

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -9,6 +9,14 @@ module SSHKit
         SSHKit.config.output = SSHKit::Formatter::BlackHole.new($stdout)
       end
 
+      def test_capture
+        captured_command_result = ''
+        Local.new do
+          captured_command_result = capture(:echo, 'foo')
+        end.run
+        assert_equal 'foo', captured_command_result
+      end
+
       def test_execute_raises_on_non_zero_exit_status_and_captures_stdout_and_stderr
         err = assert_raises SSHKit::Command::Failed do
           Local.new do
@@ -16,6 +24,16 @@ module SSHKit
           end.run
         end
         assert_equal "echo stdout: Nothing written\necho stderr: Test capturing stderr\n", err.message
+      end
+
+      def test_test
+        succeeded_test_result = failed_test_result = nil
+        Local.new do
+          succeeded_test_result = test('[ -d ~ ]')
+          failed_test_result    = test('[ -f ~ ]')
+        end.run
+        assert_equal true,  succeeded_test_result
+        assert_equal false, failed_test_result
       end
     end
   end


### PR DESCRIPTION
I've noticed calls to `test()` and `capture()` helper methods in `run_locally` block don't behave as expected.

``` ruby
on(hosts) do |host|
  puts capture :echo, 'foo'
  # => foo

  puts test '[ -d ~ ]'
  # => true

  puts test '[ -f ~ ]'
  # => false
end

run_locally do
  puts capture :echo, 'foo'
  # =>

  puts test '[ -d ~ ]'
  # => test -d ~
  # on tag: 1.0.0
  #
  # => cap aborted!
  #    undefined method `verbosity' for "[ -d ~ ]":String
  #    ...
  # on HEAD

  puts test '[ -f ~ ]'
  # => [ -f ~ ]
  # on tag: 1.0.0
  #
  # => cap aborted!
  #    undefined method `verbosity' for "[ -f ~ ]":String
  #    ...
  # on HEAD
end
```

This is confusing and is because only `execute()` helper method is implemented in `Local` class and calls to `test()` and `capture()` methods in `run_locally` block are actually call `Printer#test` and `Printer#capture` methods.
It is great if `test()` and `capture()` methods are also implemented in `Local` class.
