### PR TITLE
Quick fix for issue 51 - error when downloading empty files

### DIFF
--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -65,29 +65,13 @@ module SSHKit
       end
 
       def upload!(local, remote, options = {})
-        ssh.scp.upload!(local, remote, options) do |ch, name, sent, total|
-          percentage = (sent.to_f * 100 / total.to_f)
-          unless percentage.nan?
-            if percentage > 0 && percentage % 10 == 0
-              info "Uploading #{name} #{percentage.round(2)}%"
-            else
-              debug "Uploading #{name} #{percentage.round(2)}%"
-            end
-          else
-            warn "Error calculating percentage #{percentage} is NaN"
-          end
-        end
+        summarizer = transfer_summarizer('Uploading')
+        ssh.scp.upload!(local, remote, options, &summarizer)
       end
 
       def download!(remote, local=nil, options = {})
-        ssh.scp.download!(remote, local, options) do |ch, name, received, total|
-          percentage = (received.to_f * 100 / total.to_f).to_i
-          if percentage > 0 && percentage % 10 == 0
-            info "Downloading #{name} #{percentage}%"
-          else
-            debug "Downloading #{name} #{percentage}%"
-          end
-        end
+        summarizer = transfer_summarizer('Downloading')
+        ssh.scp.download!(remote, local, options, &summarizer)
       end
 
       class << self
@@ -101,6 +85,23 @@ module SSHKit
       end
 
       private
+
+      def transfer_summarizer(action)
+        proc do |ch, name, transferred, total|
+          percentage = (transferred.to_f * 100 / total.to_f)
+          unless percentage.nan?
+            message = "#{action} #{name} #{percentage.round(2)}%"
+            if percentage > 0 && percentage.round % 10 == 0
+              info message
+            else
+              debug message
+            end
+          else
+            warn "Error calculating percentage #{transferred}/#{total}, " <<
+              "is #{name} empty?"
+          end
+        end
+      end
 
       def _execute(*args)
         command(*args).tap do |cmd|

--- a/test/unit/backends/test_netssh.rb
+++ b/test/unit/backends/test_netssh.rb
@@ -27,6 +27,25 @@ module SSHKit
         assert_equal false,                       backend.config.ssh_options[:forward_agent]
         assert_equal %w(publickey password),      backend.config.ssh_options[:auth_methods]
       end
+
+      def test_transfer_summarizer
+        netssh = Netssh.new(Host.new('fake'))
+
+        summarizer = netssh.send(:transfer_summarizer,'Transferring')
+
+        [
+         [1,    100, :debug, 'Transferring afile 1.0%'],
+         [1,    3,   :debug, 'Transferring afile 33.33%'],
+         [0,    1,   :debug, 'Transferring afile 0.0%'],
+         [1,    2,   :info,  'Transferring afile 50.0%'],
+         [0,    0,   :warn,  'percentage 0/0'],
+         [1023, 343, :debug, 'Transferring'],
+        ].each do |transferred,total,method,substring|
+          netssh.expects(method).with { |msg| msg.include?(substring) }
+          summarizer.call(nil,'afile',transferred,total)
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
I moved the upload / download logging logic into a separate method and added a unit test. It no longer fails when downloading an empty file, but does log the same warning twice -- pls let me know if this needs to be fixed.

(Would have added a functional test, but I'm having trouble getting the required version of Vagrant to work on my machine.)
