### PR TITLE
Remove vagrant dev dependency

### DIFF
--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('unindent')
   gem.add_development_dependency('mocha')
   gem.add_development_dependency('debugger')
-  gem.add_development_dependency('vagrant')
 
   gem.add_development_dependency('yard')
   gem.add_development_dependency('redcarpet')


### PR DESCRIPTION
Vagrant no longer installable by gem and the old ffi (0.6.4 vs. the current 1.9.3) version it pulls won't compile everywhere (yes I do test on Windows x64 as well)
