### PR TITLE
full_capture method

### DIFF
--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -4,6 +4,10 @@ module SSHKit
 
     MethodUnavailableError = Class.new(SSHKit::StandardError)
 
+    module Result
+      attr_accessor :exit_status,:stderr,:stdout
+    end
+    
     class Abstract
 
       attr_reader :host
@@ -70,10 +74,6 @@ module SSHKit
         raise MethodUnavailableError
       end
 
-      def full_capture(command,args=[])
-        raise MethodUnavailableError
-      end
-
       def within(directory, &block)
         (@pwd ||= []).push directory.to_s
         execute <<-EOTEST, verbosity: Logger::DEBUG
@@ -137,6 +137,14 @@ module SSHKit
         raise "No Connection Pool Implementation"
       end
 
+      def result(r,cmd)
+        r.tap do |res|
+          res.extend(SSHKit::Backend::Result)
+          res.exit_status=cmd.exit_status
+          res.stdout=cmd.full_stdout.strip
+          res.stderr=cmd.full_stderr.strip
+        end
+      end
     end
 
   end

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -27,16 +27,8 @@ module SSHKit
 
       def capture(*args)
         options = args.extract_options!.merge(verbosity: Logger::DEBUG)
-        _execute(*[*args, options]).full_stdout.strip
-      end
-
-      def full_capture(*args)
-        options = args.extract_options!.merge(
-          raise_on_non_zero_exit: false,
-          verbosity: Logger::DEBUG
-        )
         cmd=_execute(*[*args, options])
-        [cmd.exit_status,cmd.full_stdout.strip,cmd.full_stderr.strip]
+        result(cmd.full_stdout.strip,cmd)
       end
 
       private

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -73,18 +73,10 @@ module SSHKit
 
       def capture(*args)
         options = args.extract_options!.merge(verbosity: Logger::DEBUG)
-        _execute(*[*args, options]).full_stdout.strip
+        cmd=_execute(*[*args, options])
+        result(cmd.full_stdout.strip,cmd)
       end
       
-      def full_capture(*args)
-        options = args.extract_options!.merge(
-          raise_on_non_zero_exit: false,
-          verbosity: Logger::DEBUG
-        )
-        cmd=_execute(*[*args, options])
-        [cmd.exit_status,cmd.full_stdout.strip,cmd.full_stderr.strip]
-      end
-
       def upload!(local, remote, options = {})
         summarizer = transfer_summarizer('Uploading')
         ssh.scp.upload!(local, remote, options, &summarizer)

--- a/lib/sshkit/backends/printer.rb
+++ b/lib/sshkit/backends/printer.rb
@@ -24,15 +24,6 @@ module SSHKit
       end
       alias :capture! :capture
 
-      def full_capture(*args)
-        options = args.extract_options!.merge(
-          raise_on_non_zero_exit: false,
-          verbosity: Logger::DEBUG
-        )
-        cmd=execute(*[*args, options])
-        [cmd.exit_status,cmd.full_stdout.strip,cmd.full_stderr.strip]
-      end
-
       private
 
       def output

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -59,6 +59,10 @@ module SSHKit
               captured_command_result = capture(:hostname)
             end.run
             assert_equal "lucid32", captured_command_result
+            assert(captured_command_result.respond_to?(:stdout), "No stdout.")
+            assert_equal(captured_command_result.to_s, captured_command_result.stdout)
+            assert(captured_command_result.respond_to?(:stderr), "No stderr.")
+            assert(captured_command_result.respond_to?(:exit_status), "No exit_status.")
           end
         end
       end


### PR DESCRIPTION
Allows access to command output and exit status
This is proof of concept, ideally this would be the capture() method's behaviour but we might break too many things by changing it.

As an aside, execute() behaves differently in Printer than in the classes derived from Printer:
Printer#execute returns the Command instance, while the Printer-derived backends return the value of Command#success?
