### PR TITLE
Use a connection pool to reuse SSH connections.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,29 +3,35 @@
 This file is written in reverse chronological order, newer releases will
 appear at the top.
 
+## (Unreleased)
+
+* Connection pooling. SSH connections are reused across multiple invocations
+  of `on()`, which can result in significant performance gains. See:
+  https://github.com/capistrano/sshkit/pull/70.
+
 ## 1.2.0
 
   * Support picking up a project local SSH config file, if a SSH config file
     exists at ./.ssh/config it will be merged with the ~/.ssh/config. This is
-    ideal for defining project-local proxies/gateways, etc. Thanks to Alex 
+    ideal for defining project-local proxies/gateways, etc. Thanks to Alex
     @0rca Vzorov.
-  * Tests and general improvements to the Printer backends (mostly used 
+  * Tests and general improvements to the Printer backends (mostly used
     internally). Thanks to Michael @miry Nikitochkin.
-  * Update the net-scp dependency version. Thanks again to Michael @miry 
+  * Update the net-scp dependency version. Thanks again to Michael @miry
     Nikitochkin.
   * Improved command map. This feature allows mapped variables to be pushed
     and unshifted onto the mapping so that the Capistrano extensions for
     rbenv and bundler, etc can work together. For discussion about the reasoning
-    see https://github.com/capistrano/capistrano/issues/639 and 
+    see https://github.com/capistrano/capistrano/issues/639 and
     https://github.com/capistrano/sshkit/pull/45. A big thanks to Kir @kirs
     Shatrov.
   * `test()` and `capture()` now behave as expected inside a `run_locally` block
     meaning that they now run on your local machine, rather than erring out. Thanks
     to Kentaro @kentaroi Imai.
-  * The `:wait` option is now successfully passed to the runner now. Previously the 
+  * The `:wait` option is now successfully passed to the runner now. Previously the
     `:wait` option was ignored. Thanks to Jordan @jhollinger Hollinger for catching
     the mistake in our test coverage.
-  * Fixes and general improvements to the `download()` method which until now was 
+  * Fixes and general improvements to the `download()` method which until now was
     quite naïve. Thanks to @chqr.
 
 ## 1.1.0

--- a/README.md
+++ b/README.md
@@ -194,6 +194,29 @@ and defaults to `Logger::INFO`.
 
 At present the `Logger::WARN`, `ERROR` and `FATAL` are not used.
 
+## Connection Pooling
+
+SSHKit uses a simple connection pool (enabled by default) to reduce the
+cost of negotiating a new SSH connection for every `on()` block. Depending on
+usage and network conditions, this can add up to a significant time savings.
+In one test, a basic `cap deploy` ran 15-20 seconds faster thanks to the
+connection pooling added in recent versions of SSHKit.
+
+To prevent connections from "going stale", an existing pooled connection will
+be replaced with a new connection if it hasn't been used for more than 30
+seconds. This timeout can be changed as follows:
+
+```ruby
+SSHKit::Backend::Netssh.pool.idle_timeout = 60 # seconds
+```
+
+If you suspect the connection pooling is causing problems, you can disable the
+pooling behavior entirely by setting the idle_timeout to zero:
+
+```ruby
+SSHKit::Backend::Netssh.pool.idle_timeout = 0 # disabled
+```
+
 ## Known Issues
 
 * No handling of slow / timed out connections
@@ -225,9 +248,9 @@ At present the `Logger::WARN`, `ERROR` and `FATAL` are not used.
   a string to/from a remote file.
 * No closing of connections, the abstract backend class should include a
   cleanup method which is empty but can be overriden by other implementations.
-* No conncetion pooling, the `connection` method of the NetSSH backend could
+* ~~No conncetion pooling, the `connection` method of the NetSSH backend could
   easily be modified to look into some connection factory for it's objects,
-  saving half a second when running lots of `on()` blocks.
+  saving half a second when running lots of `on()` blocks.~~
 * Documentation! (YARD style)
 * Wrap all commands in a known shell, that is that `execute('uptime')` should
   be converted into `sh -c 'uptime'` to ensure that we have a consistent shell

--- a/lib/sshkit/all.rb
+++ b/lib/sshkit/all.rb
@@ -23,6 +23,7 @@ require_relative 'runners/group'
 require_relative 'runners/null'
 
 require_relative 'backends/abstract'
+require_relative 'backends/connection_pool'
 require_relative 'backends/printer'
 require_relative 'backends/netssh'
 require_relative 'backends/local'

--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -129,10 +129,6 @@ module SSHKit
         SSHKit::Command.new(*[*args, options.merge({in: @pwd.nil? ? nil : File.join(@pwd), env: @env, host: @host, user: @user, group: @group})])
       end
 
-      def connection
-        raise "No Connection Pool Implementation"
-      end
-
     end
 
   end

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -1,0 +1,71 @@
+require "monitor"
+
+module SSHKit
+
+  module Backend
+
+    class ConnectionPool
+
+      attr_accessor :idle_timeout
+
+      def initialize
+        self.idle_timeout = 30
+        @connections = {}
+        @monitor = Monitor.new
+      end
+
+      def create_or_reuse_connection(*new_connection_args, &block)
+        # Optimization: completely bypass the pool if idle_timeout is zero.
+        return yield(*new_connection_args) if idle_timeout == 0
+
+        key = new_connection_args.to_s
+        entry = find_and_reject_invalid(key) { |e| e.expired? || e.closed? }
+
+        if entry.nil?
+          entry = store_entry(key, yield(*new_connection_args))
+        end
+
+        entry.expires_at = Time.now + idle_timeout if idle_timeout
+        entry.connection
+      end
+
+      private
+
+      def find_and_reject_invalid(key, &block)
+        synchronize do
+          entry = @connections[key]
+          invalid = entry && yield(entry)
+
+          @connections.delete(entry) if invalid
+
+          invalid ? nil : entry
+        end
+      end
+
+      def store_entry(key, connection)
+        synchronize do
+          @connections[key] = Entry.new(connection)
+        end
+      end
+
+      def synchronize(&block)
+        @monitor.synchronize(&block)
+      end
+
+
+      Entry = Struct.new(:connection) do
+        attr_accessor :expires_at
+
+        def expired?
+          expires_at && Time.now > expires_at
+        end
+
+        def closed?
+          connection.respond_to?(:closed?) && connection.closed?
+        end
+      end
+
+    end
+
+  end
+end

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -86,7 +86,11 @@ module SSHKit
         ssh.scp.download!(remote, local, options, &summarizer)
       end
 
+      @pool = SSHKit::Backend::ConnectionPool.new
+
       class << self
+        attr_accessor :pool
+
         def configure
           yield config
         end
@@ -166,10 +170,11 @@ module SSHKit
       def ssh
         @ssh ||= begin
           host.ssh_options ||= Netssh.config.ssh_options
-          Net::SSH.start(
+          self.class.pool.create_or_reuse_connection(
             String(host.hostname),
             host.username,
-            host.netssh_options
+            host.netssh_options,
+            &Net::SSH.method(:start)
           )
         end
       end

--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -1,0 +1,77 @@
+require 'helper'
+require 'ostruct'
+
+module SSHKit
+  module Backend
+    class TestConnectionPool < UnitTest
+
+      def pool
+        @pool ||= SSHKit::Backend::ConnectionPool.new
+      end
+
+      def connect
+        ->(*args) { Object.new }
+      end
+
+      def connect_and_close
+        ->(*args) { OpenStruct.new(:closed? => true) }
+      end
+
+      def echo_args
+        ->(*args) { args }
+      end
+
+      def test_default_idle_timeout
+        assert_equal 30, pool.idle_timeout
+      end
+
+      def test_connection_factory_receives_args
+        args = %w(a b c)
+        conn = pool.create_or_reuse_connection(*args, &echo_args)
+
+        assert_equal args, conn
+      end
+
+      def test_connections_are_reused
+        conn1 = pool.create_or_reuse_connection("conn", &connect)
+        conn2 = pool.create_or_reuse_connection("conn", &connect)
+
+        assert_equal conn1, conn2
+      end
+
+      def test_zero_idle_timeout_disables_resuse
+        pool.idle_timeout = 0
+
+        conn1 = pool.create_or_reuse_connection("conn", &connect)
+        conn2 = pool.create_or_reuse_connection("conn", &connect)
+
+        refute_equal conn1, conn2
+      end
+
+      def test_expired_connection_is_not_reused
+        pool.idle_timeout = 0.1
+
+        conn1 = pool.create_or_reuse_connection("conn", &connect)
+        sleep(pool.idle_timeout)
+        conn2 = pool.create_or_reuse_connection("conn", &connect)
+
+        refute_equal conn1, conn2
+      end
+
+      def test_closed_connection_is_not_reused
+        conn1 = pool.create_or_reuse_connection("conn", &connect_and_close)
+        conn2 = pool.create_or_reuse_connection("conn", &connect)
+
+        refute_equal conn1, conn2
+      end
+
+      def test_connections_with_different_args_are_not_reused
+        conn1 = pool.create_or_reuse_connection("conn1", &connect)
+        conn2 = pool.create_or_reuse_connection("conn2", &connect)
+
+        refute_equal conn1, conn2
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
### TODO
- [x] Make it thread safe
- [x] Tests
- [x] README
- [x] CHANGELOG

What do you think of this implementation for reusing SSH connections via a simple connection pool? (In response to #69.)

I tried to minimize the impact to existing code. The changes consist of one new class, `Backend::ConnectionPool`, and a few changes in `netssh.rb`.

I saw that there was a placeholder `connection` method in `Backend::Abstract` for pooling, but I think this implementation is cleaner. I don’t think pooling is something that can be generalized in the superclass. Not to mention the other Backend implementations (`Local`, `Skipper`) have no use for it.

If you think this is a good approach, I can work on adding tests, as well as updating the README and CHANGELOG.

More details from my commit message:

---

Using a connection pool saves time of negotiating a new SSH connection for every SSHKit `on()` block. When testing with a simple capistrano recipe, a `cap deploy` ran 10-15% faster with this connection pool.

By default, an existing pooled connection will be replaced with a new connection if it hasn't been used for more than 30 seconds. This can be changed, e.g.:

```
SSHKit::Backend::Netssh.pool.idle_timeout = 60 # seconds
```

Setting the timeout to 0 will disable pooling (connections will not be reused).

Note that the connection pool will not recover gracefully if a connection somehow "goes bad". For example, if the server closes an idle connection, or if the underlying socket gets reset, a subsequent command sent to that server could fail, and the command will not be retried with a new connection. Therefore it is a good idea to use a conservative (small) value for the idle_timeout.
