### PR TITLE
SSHKit::Command: Changed it include the exit status code in exception message

### DIFF
--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -89,6 +89,7 @@ module SSHKit
       @exit_status = new_exit_status
       if options[:raise_on_non_zero_exit] && exit_status > 0
         message = ""
+        message += "#{command} exit status: " + exit_status.to_s + "\n"
         message += "#{command} stdout: " + (stdout.strip.empty? ? "Nothing written" : stdout.strip) + "\n"
         message += "#{command} stderr: " + (stderr.strip.empty? ? "Nothing written" : stderr.strip) + "\n"
         raise Failed, message

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -23,7 +23,7 @@ module SSHKit
             execute :echo, "'Test capturing stderr' 1>&2; false"
           end.run
         end
-        assert_equal "echo stdout: Nothing written\necho stderr: Test capturing stderr\n", err.message
+        assert_equal "echo exit status: 256\necho stdout: Nothing written\necho stderr: Test capturing stderr\n", err.message
       end
 
       def test_test

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -69,7 +69,7 @@ module SSHKit
             execute :echo, "'Test capturing stderr' 1>&2; false"
           end.run
         end
-        assert_equal "echo stdout: Nothing written\necho stderr: Test capturing stderr\n", err.message
+        assert_equal "echo exit status: 1\necho stdout: Nothing written\necho stderr: Test capturing stderr\n", err.message
       end
 
       def test_test_does_not_raise_on_non_zero_exit_status

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -205,7 +205,7 @@ module SSHKit
       error = assert_raises SSHKit::Command::Failed do
         Command.new(:whoami).exit_status = 1
       end
-      assert_equal "whoami stdout: Nothing written\nwhoami stderr: Nothing written\n", error.message
+      assert_equal "whoami exit status: 1\nwhoami stdout: Nothing written\nwhoami stderr: Nothing written\n", error.message
     end
 
   end


### PR DESCRIPTION
Hello.  I had an experience setting up Capistrano 3 a few months ago (for the Rails Rumble event).  I had to debug a lot of failing SSH commands, and I found that the messages from Capistrano were not very helpful when the remote command was not found on the server.  Here is an example of what SSHkit outputs when you try to run a command that isn't found on the remote server:

```
INFO [364f9b8e] Running /usr/bin/env fumble on davidegrayson
/home/david/.gem/ruby/2.0.0/gems/sshkit-1.1.0/lib/sshkit/command.rb:94:in `exit_status=': fumble stdout: Nothing written (SSHKit::Command::Failed)
fumble stderr: Nothing written
        from /home/david/.gem/ruby/2.0.0/gems/sshkit-1.1.0/lib/sshkit/backends/netssh.rb:125:in `block (4 levels) in _execute'
        from /home/david/.gem/ruby/2.0.0/gems/net-ssh-2.7.0/lib/net/ssh/connection/channel.rb:551:in `call'
        from /home/david/.gem/ruby/2.0.0/gems/net-ssh-2.7.0/lib/net/ssh/connection/channel.rb:551:in `do_request'
......
```

This pull request is my suggestion for how to start addressing that.  It simply adds the exit status code to the message that reports what was written to stdout and stderr.  This should make it easier to figure out what is going on; for example people can learn that "exit status: 127" means the command is not found and that will help them debug their capistrano/sshkit problems.  This is similar to Rake and GNU Make: both of those tools report the exit status when your command fails.

For this pull request, I did update the tests that I think need to be updated and ran them, but I did not run all the tests because I didn't want to install vagrant and figure out how to configure it.

Thanks!
