### PR TITLE
Be consistent with class method syntax

### DIFF
--- a/lib/sshkit.rb
+++ b/lib/sshkit.rb
@@ -3,29 +3,31 @@ module SSHKit
   StandardError = Class.new(::StandardError)
 
   class << self
+    
     attr_accessor :config
-  end
 
-  def self.capture_output(io, &block)
-    original_io = config.output
-    config.output = io
-    config.output.extend(SSHKit::Utils::CaptureOutputMethods)
-    yield
-  ensure
-    config.output = original_io
-  end
+    def capture_output(io, &block)
+      original_io = config.output
+      config.output = io
+      config.output.extend(SSHKit::Utils::CaptureOutputMethods)
+      yield
+    ensure
+      config.output = original_io
+    end
 
-  def self.configure
-    @@config ||= Configuration.new
-    yield config
-  end
+    def configure
+      @@config ||= Configuration.new
+      yield config
+    end
 
-  def self.config
-    @@config ||= Configuration.new
-  end
+    def config
+      @@config ||= Configuration.new
+    end
 
-  def self.reset_configuration!
-    @@config = nil
+    def reset_configuration!
+      @@config = nil
+    end
+    
   end
 
 end


### PR DESCRIPTION
Mixture of `class << self` and `self.method` in the same class - this reads more cleanly.
