### PR TITLE
Removing unnecessary require.

### DIFF
--- a/lib/sshkit/dsl.rb
+++ b/lib/sshkit/dsl.rb
@@ -1,5 +1,3 @@
-require_relative '../sshkit'
-
 module SSHKit
 
   module DSL


### PR DESCRIPTION
This will remove warnings like:
/usr/local/lib/ruby/gems/2.1.0/gems/sshkit-1.3.0/lib/sshkit.rb:3: warning: already initialized constant SSHKit::StandardError
/usr/local/Cellar/ruby/2.1.0/lib/ruby/gems/2.1.0/gems/sshkit-1.3.0/lib/sshkit.rb:3: warning: previous definition of StandardError was here
