### PR TITLE
Adding example of using `execute`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ on %w{1.example.com 2.example.com}, in: :sequence, wait: 5 do
       with rails_env: :production do
         rake   "assets:precompile"
         runner "S3::Sync.notify"
+        execute "node", "socket_server.js"
       end
     end
   end


### PR DESCRIPTION
Commands with spaces are not passed the environment variables (I don't really know why), so why not put an example of how to use `execute` properly right into README.

They'll see it's not working, come back to README, and see this proper example, and they'll try it, and it'll work.

(Took me digging into the code to figure out while I was trying to deploy my Meteor app.)
