### PR TITLE
Use thread local for storing connection pool

### DIFF
--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -35,24 +35,16 @@ module SSHKit
       end
 
       def find_and_reject_invalid(key, &block)
-        synchronize do
-          entry = connections[key]
-          invalid = entry && yield(entry)
+        entry = connections[key]
+        invalid = entry && yield(entry)
 
-          connections.delete(entry) if invalid
+        connections.delete(entry) if invalid
 
-          invalid ? nil : entry
-        end
+        invalid ? nil : entry
       end
 
       def store_entry(key, connection)
-        synchronize do
-          connections[key] = Entry.new(connection)
-        end
-      end
-
-      def synchronize(&block)
-        @monitor.synchronize(&block)
+        connections[key] = Entry.new(connection)
       end
 
 


### PR DESCRIPTION
This allows multiple threads to issue commands to the same SSH host. Each thread gets its own connection pool. Solves #99.
