### PR TITLE
Add open3 JRuby bugs workaround

### DIFF
--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -38,7 +38,13 @@ module SSHKit
 
           cmd.started = Time.now
 
-          stdout, stderr, exit_status = Open3.capture3(cmd.to_command)
+          stdout, stderr, exit_status =
+            if RUBY_ENGINE == 'jruby'
+              _, o, e, t = Open3.popen3('/usr/bin/env', 'sh', '-c', cmd.to_command)
+              [o.read, e.read, t.value]
+            else
+              Open3.capture3(cmd.to_command)
+            end
 
           cmd.stdout = stdout
           cmd.full_stdout += stdout

--- a/test/unit/backends/test_local.rb
+++ b/test/unit/backends/test_local.rb
@@ -1,0 +1,18 @@
+require 'helper'
+
+module SSHKit
+  module Backend
+    class TestLocal < UnitTest
+
+      def local
+        @local ||= Local.new
+      end
+
+      def test_execute
+        assert_equal true, local.execute('uname -a')
+        assert_equal true, local.execute
+        assert_equal true, local.execute('cd && pwd')
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are a couple bugs related to `Open3.capture3` and `Open3.popen3`.

```
>> SSHKit::Backend::Local.new.execute('uname -a')
 INFO [341e3662] Running /usr/bin/env uname -a on
IOError: Cannot run program "uname -a" (in directory "/private/tmp/sshkit"): error=2, No such file or directory
    from org/jruby/RubyIO.java:4375:in `popen3'
    from /Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/1.9/open3.rb:74:in `popen3'
    from /Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/1.9/open3.rb:272:in `capture3'
    from /Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/gems/sshkit-1.3.0/lib/sshkit/backends/local.rb:41:in `_execute'
    from org/jruby/RubyKernel.java:1891:in `tap'
    from /Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/gems/sshkit-1.3.0/lib/sshkit/backends/local.rb:36:in `_execute'
    from /Users/kes/.rbenv/versions/jruby-1.7.10/lib/ruby/gems/shared/gems/sshkit-1.3.0/lib/sshkit/backends/local.rb:25:in `execute'
    from (irb):3:in `evaluate'
    from org/jruby/RubyKernel.java:1119:in `eval'
    from org/jruby/RubyKernel.java:1519:in `loop'
    from org/jruby/RubyKernel.java:1282:in `catch'
    from org/jruby/RubyKernel.java:1282:in `catch'
    from /Users/kes/.rbenv/versions/jruby-1.7.10/bin/irb:13:in `(root)'
```

https://github.com/jruby/jruby/issues/1187#issuecomment-31816243
The other one is that `Open3.popen3` returns empty output if output read inside `popen3` block.

So I added temporary hack that fixes (I hope) this problem.
