### PR TITLE
Flush connections to avoid non-deterministic tests

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -20,6 +20,11 @@ class UnitTest < MiniTest::Unit::TestCase
     SSHKit.reset_configuration!
   end
 
+  SSHKit::Backend::ConnectionPool.class_eval do
+    def flush_connections
+      Thread.current[:sshkit_pool] = {}
+    end
+  end
 end
 
 class FunctionalTest < MiniTest::Unit::TestCase

--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -59,6 +59,8 @@ module SSHKit
       end
 
       def test_closed_connection_is_not_reused
+        # Ensure there aren't any other open connections
+        pool.flush_connections()
         conn1 = pool.create_or_reuse_connection("conn", &connect_and_close)
         conn2 = pool.create_or_reuse_connection("conn", &connect)
 


### PR DESCRIPTION
The build is failing because one unit test depends on the connection pool. This pool get's flushed before that specific test to avoid non-deterministic results.
