### PR TITLE
Get rid of arguments not used in a Thread.new

### DIFF
--- a/lib/sshkit/runners/parallel.rb
+++ b/lib/sshkit/runners/parallel.rb
@@ -9,7 +9,7 @@ module SSHKit
         threads = []
         hosts.each do |host|
           threads << Thread.new(host) do |h|
-            backend(host, &block).run
+            backend(h, &block).run
           end
         end
         threads.map(&:join)


### PR DESCRIPTION
Very simple improvement.

When I read the code I was expecting to see how `h` was being used and it turns out that we don't even use it and also we don't it. We have the `host` variable from the function context.
