### PR TITLE
Fix "envivonment" typo

### DIFF
--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -151,7 +151,7 @@ module SSHKit
       (SSHKit.config.default_env || {}).merge(options[:env] || {})
     end
 
-    def envivonment_string
+    def environment_string
       environment_hash.collect do |key,value|
         "#{key.to_s.upcase}=#{value}"
       end.join(' ')
@@ -159,7 +159,7 @@ module SSHKit
 
     def with(&block)
       return yield unless environment_hash.any?
-      "( #{envivonment_string} %s )" % yield
+      "( #{environment_string} %s )" % yield
     end
 
     def user(&block)


### PR DESCRIPTION
The "environment_string" method was called "envivonment_string" before. It doesn't show up anywhere else, so I believe it's a safe and sane change.
