### PR TITLE
Allow verbosity control in capture

### DIFF
--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -26,7 +26,7 @@ module SSHKit
       end
 
       def capture(*args)
-        options = args.extract_options!.merge(verbosity: Logger::DEBUG)
+        options = { verbosity: Logger::DEBUG }.merge(args.extract_options!)
         _execute(*[*args, options]).full_stdout.strip
       end
 

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -72,7 +72,7 @@ module SSHKit
       end
 
       def capture(*args)
-        options = args.extract_options!.merge(verbosity: Logger::DEBUG)
+        options = { verbosity: Logger::DEBUG }.merge(args.extract_options!)
         _execute(*[*args, options]).full_stdout.strip
       end
 


### PR DESCRIPTION
Currently `capture`'s verbosity is [forced to be `Logger::DEBUG`](https://github.com/capistrano/sshkit/blob/master/lib/sshkit/backends/netssh.rb#L75).

This patch allows one to override `capture`'s verbosity for a single command like this:

```
capture '<COMMAND I WANT TO SEE OUTPUT FOR WHILE IN INFO LEVEL>', verbosity: Logger::INFO
```
