### PR TITLE
Replace Term::ANSIColor with a lighter solution

### DIFF
--- a/lib/sshkit/all.rb
+++ b/lib/sshkit/all.rb
@@ -3,6 +3,7 @@ require_relative '../core_ext/hash'
 
 require_relative 'host'
 
+require_relative 'color'
 require_relative 'command'
 require_relative 'command_map'
 require_relative 'configuration'

--- a/lib/sshkit/color.rb
+++ b/lib/sshkit/color.rb
@@ -1,0 +1,13 @@
+require 'colorize'
+module Color
+  STYLES = [String::COLORS, String::MODES].flat_map(&:keys)
+
+  STYLES.each do |style|
+    instance_eval %{
+    def #{style}(string='')
+      string = yield if block_given?
+      string.colorize(:#{style})
+    end
+    }
+  end
+end

--- a/lib/sshkit/formatters/dot.rb
+++ b/lib/sshkit/formatters/dot.rb
@@ -1,5 +1,3 @@
-require 'term/ansicolor'
-
 module SSHKit
 
   module Formatter
@@ -17,7 +15,7 @@ module SSHKit
       private
 
       def c
-        @c ||= Term::ANSIColor
+        @c ||= Color
       end
 
     end

--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -1,5 +1,3 @@
-require 'term/ansicolor'
-
 module SSHKit
 
   module Formatter
@@ -53,7 +51,7 @@ module SSHKit
       end
 
       def c
-        @c ||= Term::ANSIColor
+        @c ||= Color
       end
 
       def uuid(obj)
@@ -61,9 +59,7 @@ module SSHKit
       end
 
       def level(verbosity)
-        # Insane number here accounts for the control codes added
-        # by term-ansicolor
-        sprintf "%14s ", c.send(level_formatting(verbosity), level_names(verbosity))
+        c.send(level_formatting(verbosity), level_names(verbosity))
       end
 
       def level_formatting(level_num)

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -19,12 +19,11 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('net-ssh', '>= 2.8.0')
   gem.add_runtime_dependency('net-scp', '>= 1.1.2')
-  gem.add_runtime_dependency('term-ansicolor')
+  gem.add_runtime_dependency('colorize')
 
   gem.add_development_dependency('minitest', ['>= 2.11.3', '< 2.12.0'])
   gem.add_development_dependency('rake')
   gem.add_development_dependency('turn')
   gem.add_development_dependency('unindent')
   gem.add_development_dependency('mocha')
-
 end

--- a/test/unit/formatters/test_dot.rb
+++ b/test/unit/formatters/test_dot.rb
@@ -51,14 +51,14 @@ module SSHKit
       command = SSHKit::Command.new(:ls)
       command.exit_status = 0
       dot << command
-      assert_equal "\e[32m.\e[0m", output.strip
+      assert_equal "\e[0;32;49m.\e[0m", output.strip
     end
     
     def test_command_failure
       command = SSHKit::Command.new(:ls, {raise_on_non_zero_exit: false})
       command.exit_status = 1
       dot << command
-      assert_equal "\e[31m.\e[0m", output.strip
+      assert_equal "\e[0;31;49m.\e[0m", output.strip
     end
 
   end

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -24,27 +24,27 @@ module SSHKit
 
     def test_logging_fatal
       pretty << SSHKit::LogMessage.new(Logger::FATAL, "Test")
-      assert_equal output.strip, " \e[31mFATAL\e[0m Test \n".strip
+      assert_equal output.strip, "\e[0;31;49mFATAL\e[0mTest"
     end
 
     def test_logging_error
       pretty << SSHKit::LogMessage.new(Logger::ERROR, "Test")
-      assert_equal output.strip, " \e[31mERROR\e[0m Test \n".strip
+      assert_equal output.strip, "\e[0;31;49mERROR\e[0mTest"
     end
 
     def test_logging_warn
       pretty << SSHKit::LogMessage.new(Logger::WARN, "Test")
-      assert_equal output.strip, " \e[33mWARN\e[0m Test \n".strip
+      assert_equal output.strip, "\e[0;33;49mWARN\e[0mTest".strip
     end
 
     def test_logging_info
       pretty << SSHKit::LogMessage.new(Logger::INFO, "Test")
-      assert_equal output.strip, " \e[34mINFO\e[0m Test \n".strip
+      assert_equal output.strip, "\e[0;34;49mINFO\e[0mTest".strip
     end
 
     def test_logging_debug
       pretty << SSHKit::LogMessage.new(Logger::DEBUG, "Test")
-      assert_equal output.strip, " \e[30mDEBUG\e[0m Test \n".strip
+      assert_equal output.strip, "\e[0;30;49mDEBUG\e[0mTest".strip
     end
 
   end


### PR DESCRIPTION
The `term-ansicolor` gem includes some extensive dependencies by way of
`tins`. This seems unnecessary given the extent of the use in `SSHKit`.
This commit replaces the dependency with the lighter `colorize` gem and
moves any color implementation behind the `SSHKit::Color` module, with a
matching interface.
