### PR TITLE
Add gateway support.

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -363,3 +363,52 @@ Replace `on` with `run_locally`
       end
     end
 
+## Using a gateway
+
+SSHKit allow you to use gateway(s). 
+All subsequent connections will be tunneled through the gateway(s) (using SSH forwarded ports). To tell SSHKit about your gateways you can either :
+
+* define a global gateway
+
+```ruby
+SSHKit.config.backend.configure do |ssh|
+    ssh.gateway = "user@my-gateway"
+end
+```
+
+The gateway definition follows the same syntax as host definition. This means you can define your global gateway like this:
+
+```ruby
+SSHKit.config.backend.configure do |ssh|
+    ssh.gateway = {
+        hostname: "my-gateway",
+        user: "user",
+        ssh_options: {
+        ...
+        }
+    }
+end
+```
+
+    
+* or define a per host gateway.   
+
+```ruby
+host = SSHKit::Host.new(
+    :hostname => "private.server", 
+    :user => "internal.user", 
+    :gateway => "user@my-gateway") 
+```
+
+or
+
+```ruby
+host = SSHKit::Host.new(
+    :hostname => "private.server", 
+    :user => "internal.user", 
+    :gateway => {
+        :hostname => "my-gateway", 
+        :user => "user", 
+        :ssh_options => {...}
+    })
+```

--- a/lib/sshkit/host.rb
+++ b/lib/sshkit/host.rb
@@ -6,7 +6,7 @@ module SSHKit
 
   class Host
 
-    attr_accessor :password, :hostname, :port, :user, :ssh_options
+    attr_accessor :password, :hostname, :port, :user, :ssh_options, :gateway
 
     def key=(new_key)
       @keys = [new_key]

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
   gem.version       = SSHKit::VERSION
 
   gem.add_runtime_dependency('net-ssh', '>= 2.8.0')
+  gem.add_runtime_dependency('net-ssh-gateway', '>= 1.2.0')
   gem.add_runtime_dependency('net-scp', '>= 1.1.2')
   gem.add_runtime_dependency('colorize')
 

--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -39,6 +39,17 @@ module SSHKit
         assert_equal conn1, conn2
       end
 
+      def test_connections_are_reused_threads
+        conn1 = nil
+        conn2 = nil
+        thr1 = Thread.new {conn1 = pool.create_or_reuse_connection("conn", &connect)}
+        thr2 = Thread.new {conn2 =  pool.create_or_reuse_connection("conn", &connect)}
+        thr1.join
+        thr2.join
+        refute_nil  conn1
+        assert_equal conn1, conn2
+      end
+
       def test_zero_idle_timeout_disables_reuse
         pool.idle_timeout = 0
 


### PR DESCRIPTION
When a gateway is declared (globally or per host), a connection is created to this gateway to encapsulate
all the connections to the hosts using this gateway.

Add hash SSHKit::Backend::ConnectioPool.connections instead of using Thread.current hash.
This allows for multiple threads requesting connections to the same host to reuse the same connections.

Add SSHKit::Host.gateway

Add SSHKit::Backend::Netssh::Configuration.gateway

M