### PR TITLE
Fix typo in EXAMPLES.md

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -217,7 +217,7 @@ circumstances the program will hang anyway when the SSH session exits.
       execute!(:echo, '"Example Message!" 1>&2; false')
     end
 
-This will raise `SSHKit::Command:Failed` with the `#message` "Example Message!"`
+This will raise `SSHKit::Command:Failed` with the `#message` "Example Message!"
 which will cause the command to abort.
 
 ## Make a test, or run a command which may fail without raising an error:


### PR DESCRIPTION
This typo messes up text editor's (in my case vim) color syntax.

I think recording this to the changelog is unnecessary so I didn't make any change there.
