### PR TITLE
Fix hostname logging for Local backend

### DIFF
--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -6,6 +6,7 @@ module SSHKit
     class Local < Printer
 
       def initialize(&block)
+        @host = Host.new(hostname: 'localhost') # just for logging
         @block = block
       end
 

--- a/test/unit/backends/test_local.rb
+++ b/test/unit/backends/test_local.rb
@@ -8,6 +8,10 @@ module SSHKit
         @local ||= Local.new
       end
 
+      def test_host
+        assert_equal 'localhost', local.host.to_s
+      end
+
       def test_execute
         assert_equal true, local.execute('uname -a')
         assert_equal true, local.execute


### PR DESCRIPTION
Both `Formatter::Pretty` and `Formatter::SimpleText` print the hostname along with each command being executed. But the Local backend doesn't have a `@host`, so the output looks like `running [...] on`.

This hard-codes a null `Host` object into `Backend::Local`, which is only used for logging. It's not the most elegant solution, but it's a one-line change.
#### Before

![before.png](http://cl.ly/image/1X170u1q3S2S/Image%202014-05-08%20at%204.59.35%20PM.png)
#### After

![after.png](http://cl.ly/image/3J0F0z313P1k/Image%202014-05-08%20at%205.00.03%20PM.png)
