### PR TITLE
Use `sudo -u <username>` to change users

### DIFF
--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -97,7 +97,7 @@ module SSHKit
           @group = nil
         end
         execute <<-EOTEST, verbosity: Logger::DEBUG
-          if ! sudo su #{@user} -c whoami > /dev/null
+          if ! sudo -u #{@user} whoami > /dev/null
             then echo "You cannot switch to user '#{@user}' using sudo, please check the sudoers file" 1>&2
             false
           fi

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -163,7 +163,7 @@ module SSHKit
 
     def user(&block)
       return yield unless options[:user]
-      "sudo su #{options[:user]} -c '%s'" % %Q{#{yield}}
+      "sudo -u #{options[:user]} #{environment_string + " " unless environment_string.empty?}-- sh -c '%s'" % %Q{#{yield}}
     end
 
     def in_background(&block)

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -78,7 +78,7 @@ module SSHKit
 
     def test_working_as_a_given_user
       c = Command.new(:whoami, user: :anotheruser)
-      assert_equal "sudo su anotheruser -c '/usr/bin/env whoami'", c.to_command
+      assert_equal "sudo -u anotheruser -- sh -c '/usr/bin/env whoami'", c.to_command
     end
 
     def test_working_as_a_given_group
@@ -88,7 +88,7 @@ module SSHKit
 
     def test_working_as_a_given_user_and_group
       c = Command.new(:whoami, user: :anotheruser, group: :devvers)
-      assert_equal "sudo su anotheruser -c 'sg devvers -c \\\"/usr/bin/env whoami\\\"'", c.to_command
+      assert_equal "sudo -u anotheruser -- sh -c 'sg devvers -c \\\"/usr/bin/env whoami\\\"'", c.to_command
     end
 
     def test_umask
@@ -106,13 +106,13 @@ module SSHKit
     def test_umask_with_working_directory_and_user
       SSHKit.config.umask = '007'
       c = Command.new(:touch, 'somefile', in: '/var', user: 'alice')
-      assert_equal "cd /var && umask 007 && sudo su alice -c '/usr/bin/env touch somefile'", c.to_command
+      assert_equal "cd /var && umask 007 && sudo -u alice -- sh -c '/usr/bin/env touch somefile'", c.to_command
     end
 
     def test_umask_with_env_and_working_directory_and_user
       SSHKit.config.umask = '007'
       c = Command.new(:touch, 'somefile', user: 'bob', env: {a: 'b'}, in: '/var')
-      assert_equal "cd /var && umask 007 && ( A=b sudo su bob -c '/usr/bin/env touch somefile' )", c.to_command
+      assert_equal "cd /var && umask 007 && ( A=b sudo -u bob A=b -- sh -c '/usr/bin/env touch somefile' )", c.to_command
     end
 
     def test_verbosity_defaults_to_logger_info


### PR DESCRIPTION
The principle motivation for this commit is that the command maps provided by capistrano/rbenv now work within `as()` session (previously they were dying because `RBENV_ROOT` wasn't being passed into the `sudo`'d environment).

IMO, this also fixes the now-closed capistrano/sshkit#125 (I've outlined in a comment there why I believe this is so, even in the absence of sudo documentation)
