### PR TITLE
Wrap exceptions to include the hostname

### DIFF
--- a/lib/sshkit/all.rb
+++ b/lib/sshkit/all.rb
@@ -9,6 +9,8 @@ require_relative 'command_map'
 require_relative 'configuration'
 require_relative 'coordinator'
 
+require_relative 'exception'
+
 require_relative 'logger'
 require_relative 'log_message'
 

--- a/lib/sshkit/exception.rb
+++ b/lib/sshkit/exception.rb
@@ -1,0 +1,21 @@
+module SSHKit
+
+    module Runner
+
+        class ExecuteError < StandardError
+          attr_reader :cause
+
+          def initialize cause
+            @cause = cause
+          end
+
+          def backtrace
+            @cause.backtrace
+          end
+ 
+          def backtrace_locations
+            @cause.backtrace_locations
+          end
+        end
+    end
+end

--- a/lib/sshkit/runners/parallel.rb
+++ b/lib/sshkit/runners/parallel.rb
@@ -9,7 +9,12 @@ module SSHKit
         threads = []
         hosts.each do |host|
           threads << Thread.new(host) do |h|
-            backend(h, &block).run
+            begin
+              backend(h, &block).run
+            rescue Exception => e
+              e2 = ExecuteError.new e
+              raise e2, "Exception while executing on host #{host}: #{e.message}" 
+            end
           end
         end
         threads.map(&:join)

--- a/lib/sshkit/runners/sequential.rb
+++ b/lib/sshkit/runners/sequential.rb
@@ -6,7 +6,12 @@ module SSHKit
       attr_writer :wait_interval
       def execute
         hosts.each do |host|
-          backend(host, &block).run
+          begin
+            backend(host, &block).run
+          rescue Exception => e
+            e2 = ExecuteError.new e
+            raise e2, "Exception while executing on host #{host}: #{e.message}" 
+          end
           sleep wait_interval
         end
       end


### PR DESCRIPTION
Wrap all exceptions while executing in a ExecuteError so that the host
where the exception occured can be identified.
