### PR TITLE
do not evaluate command_map in run_locally, fix rvm/rvm1-capistrano3#31

### DIFF
--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -34,7 +34,8 @@ module SSHKit
       private
 
       def _execute(*args)
-        command(*args).tap do |cmd|
+        options = { skip_command_map: true }.merge(args.extract_options!)
+        command(*[*args, options]).tap do |cmd|
           output << cmd
 
           cmd.started = Time.now

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -201,7 +201,11 @@ module SSHKit
     end
 
     def to_s
-      [SSHKit.config.command_map[command.to_sym], *Array(args)].join(' ')
+      if @options[:skip_command_map]
+      then command_string = command.to_s
+      else command_string = SSHKit.config.command_map[command.to_sym]
+      end
+      [command_string, *Array(args)].join(' ')
     end
 
     private


### PR DESCRIPTION
as described in https://github.com/rvm/rvm1-capistrano3/issues/31 it is a problem that `SSHKit.config.command_map.prefix[:rvm]` is used in `run_locally`, this is my take on fixing it
