### PR TITLE
Add quotes around environment variable values when generating environment_hash

### DIFF
--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -152,7 +152,7 @@ module SSHKit
 
     def environment_string
       environment_hash.collect do |key,value|
-        "#{key.to_s.upcase}=#{value}"
+        "#{key.to_s.upcase}=\"#{value.to_s.gsub(/"/, "\\\"")}\""
       end.join(' ')
     end
 

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -32,32 +32,32 @@ module SSHKit
     def test_including_the_env
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {rails_env: :production})
-      assert_equal "( RAILS_ENV=production /usr/bin/env rails server )", c.to_command
+      assert_equal "( RAILS_ENV=\"production\" /usr/bin/env rails server )", c.to_command
     end
 
     def test_including_the_env_with_multiple_keys
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {rails_env: :production, foo: 'bar'})
-      assert_equal "( RAILS_ENV=production FOO=bar /usr/bin/env rails server )", c.to_command
+      assert_equal "( RAILS_ENV=\"production\" FOO=\"bar\" /usr/bin/env rails server )", c.to_command
     end
 
     def test_including_the_env_doesnt_addressively_escape
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {path: '/example:$PATH'})
-      assert_equal "( PATH=/example:$PATH /usr/bin/env rails server )", c.to_command
+      assert_equal "( PATH=\"/example:$PATH\" /usr/bin/env rails server )", c.to_command
     end
 
     def test_global_env
       SSHKit.config = nil
       SSHKit.config.default_env = { default: 'env' }
       c = Command.new(:rails, 'server', env: {})
-      assert_equal "( DEFAULT=env /usr/bin/env rails server )", c.to_command
+      assert_equal "( DEFAULT=\"env\" /usr/bin/env rails server )", c.to_command
     end
 
     def test_default_env_is_overwritten_with_locally_defined
       SSHKit.config.default_env = { foo: 'bar', over: 'under' }
       c = Command.new(:rails, 'server', env: { over: 'write'})
-      assert_equal "( FOO=bar OVER=write /usr/bin/env rails server )", c.to_command
+      assert_equal "( FOO=\"bar\" OVER=\"write\" /usr/bin/env rails server )", c.to_command
     end
 
     def test_working_in_a_given_directory
@@ -67,7 +67,7 @@ module SSHKit
 
     def test_working_in_a_given_directory_with_env
       c = Command.new(:ls, '-l', in: "/opt/sites", env: {a: :b})
-      assert_equal "cd /opt/sites && ( A=b /usr/bin/env ls -l )", c.to_command
+      assert_equal "cd /opt/sites && ( A=\"b\" /usr/bin/env ls -l )", c.to_command
     end
 
     def test_having_a_host_passed
@@ -112,7 +112,7 @@ module SSHKit
     def test_umask_with_env_and_working_directory_and_user
       SSHKit.config.umask = '007'
       c = Command.new(:touch, 'somefile', user: 'bob', env: {a: 'b'}, in: '/var')
-      assert_equal "cd /var && umask 007 && ( A=b sudo -u bob A=b -- sh -c '/usr/bin/env touch somefile' )", c.to_command
+      assert_equal "cd /var && umask 007 && ( A=\"b\" sudo -u bob A=\"b\" -- sh -c '/usr/bin/env touch somefile' )", c.to_command
     end
 
     def test_verbosity_defaults_to_logger_info


### PR DESCRIPTION
With something like this:

```ruby
with upload_url: "http://foo.com?bar=foo&bar=foo" do
  ...
end
```

The `environment_string` generates a string that looks like this: `UPLOAD_URL=http://foo.com?bar=foo&bar=foo` which is invalid because it contains the ampersand (`&`). The solution I found was to wrap the values in quotes.

Was this an acceptable solution?