### PR TITLE
Make Backend::Local initialize compatible with Backend::Netssh

### DIFF
--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -5,7 +5,7 @@ module SSHKit
 
     class Local < Printer
 
-      def initialize(&block)
+      def initialize(compat=nil, &block)
         @host = Host.new(hostname: 'localhost') # just for logging
         @block = block
       end


### PR DESCRIPTION
This fix gives Backend::Local and Backend::Netssh the same initialize parameters.  More specifically, this allows you to set
set :sshkit_backend, SSHKit::Backend::Local
in your config/deploy.rb for capistrano and have it successfully deploy locally.