### PR TITLE
make SSHKit::Backend::Local#initialize to have the same interface

### DIFF
--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -5,9 +5,8 @@ module SSHKit
 
     class Local < Printer
 
-      def initialize(&block)
-        @host = Host.new(hostname: 'localhost') # just for logging
-        @block = block
+      def initialize(host=Host.new(hostname: 'localhost'), &block)
+        super
       end
 
       def run

--- a/test/unit/backends/test_local.rb
+++ b/test/unit/backends/test_local.rb
@@ -8,6 +8,10 @@ module SSHKit
         @local ||= Local.new
       end
 
+      def test_with_param
+        Local.new(Host.new('127.0.0.1'))
+      end
+
       def test_host
         assert_equal 'localhost', local.host.to_s
       end


### PR DESCRIPTION
as other backends.

One usecase for when running capistrano to deploy to localhost, with

``` ruby
set :sshkit_backend, SSHKit::Backend::Local
```

capistrano fails with error "wrong number of arguments"
