### PR TITLE
Remove unnecessary trailing wait

### DIFF
--- a/lib/sshkit/runners/sequential.rb
+++ b/lib/sshkit/runners/sequential.rb
@@ -5,17 +5,25 @@ module SSHKit
     class Sequential < Abstract
       attr_writer :wait_interval
       def execute
+        last_host = hosts.pop
+
         hosts.each do |host|
-          begin
-            backend(host, &block).run
-          rescue Exception => e
-            e2 = ExecuteError.new e
-            raise e2, "Exception while executing on host #{host}: #{e.message}" 
-          end
+          run_backend(host, &block)
           sleep wait_interval
+        end
+
+        unless last_host.nil?
+          run_backend(last_host, &block)
         end
       end
       private
+      def run_backend(host, &block)
+        backend(host, &block).run
+      rescue Exception => e
+        e2 = ExecuteError.new e
+        raise e2, "Exception while executing on host #{host}: #{e.message}"
+      end
+
       def wait_interval
         @wait_interval || options[:wait] || 2
       end


### PR DESCRIPTION
When executing sequential tasks with a wait interval, the existing behavior is to wait N seconds after each host, _including the last one_. My expectations of using a wait interval for sequential tasks is that the interval should be how long to wait _between each host_. After the last one I'd expect Capistrano to continue executing immediately. 

This is especially problematic with "longer" wait intervals such as 30 seconds. Your deploy will just hang after you think it should be moving onto the rest of the deploy.

This patch simply pops the last host and runs it outside of the sleep loop.
