### PR TITLE
Change transfer_summarizer to log on 10% boundaries

### DIFF
--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -108,12 +108,17 @@ module SSHKit
       private
 
       def transfer_summarizer(action)
+        last_name = nil
+        last_percentage = nil
         proc do |ch, name, transferred, total|
           percentage = (transferred.to_f * 100 / total.to_f)
           unless percentage.nan?
             message = "#{action} #{name} #{percentage.round(2)}%"
-            if percentage > 0 && percentage.round % 10 == 0
+            percentage_r = (percentage / 10).truncate * 10
+            if percentage_r > 0 && (last_name != name || last_percentage != percentage_r)
               info message
+              last_name = name
+              last_percentage = percentage_r
             else
               debug message
             end

--- a/test/unit/backends/test_netssh.rb
+++ b/test/unit/backends/test_netssh.rb
@@ -38,12 +38,15 @@ module SSHKit
         summarizer = netssh.send(:transfer_summarizer,'Transferring')
 
         [
-         [1,    100, :debug, 'Transferring afile 1.0%'],
-         [1,    3,   :debug, 'Transferring afile 33.33%'],
-         [0,    1,   :debug, 'Transferring afile 0.0%'],
-         [1,    2,   :info,  'Transferring afile 50.0%'],
-         [0,    0,   :warn,  'percentage 0/0'],
-         [1023, 343, :debug, 'Transferring'],
+         [1,    1000, :debug, 'Transferring afile 0.1%'],
+         [1,    100,  :debug, 'Transferring afile 1.0%'],
+         [99,   1000, :debug, 'Transferring afile 9.9%'],
+         [15,   100,  :info,  'Transferring afile 15.0%'],
+         [1,    3,    :info,  'Transferring afile 33.33%'],
+         [0,    1,    :debug, 'Transferring afile 0.0%'],
+         [1,    2,    :info,  'Transferring afile 50.0%'],
+         [0,    0,    :warn,  'percentage 0/0'],
+         [1023, 343,  :info,  'Transferring'],
         ].each do |transferred,total,method,substring|
           netssh.expects(method).with { |msg| msg.include?(substring) }
           summarizer.call(nil,'afile',transferred,total)


### PR DESCRIPTION
This change causes transfer_summarier to only log
at info level when percentage crosses 10%
boundaries, which is useful when uploading or
downloading very big files. Previously it would
log every percentage between 0% and 0.5%, then
between 9.5% and 10.5% and so on.

Fixes #169
