### PR TITLE
Allow forcing color output via environment variable SSHKIT_COLOR.

### DIFF
--- a/lib/sshkit/color.rb
+++ b/lib/sshkit/color.rb
@@ -6,7 +6,11 @@ module Color
     instance_eval %{
     def #{style}(string='')
       string = yield if block_given?
-      $stdout.tty? ? string.colorize(:#{style}) : string
+      colorize? ? string.colorize(:#{style}) : string
+    end
+
+    def colorize?
+      ENV['SSHKIT_COLOR'] || $stdout.tty?
     end
     }
   end


### PR DESCRIPTION
Hi,

on Jenkins you can install the ANSI color plugin. But even with this plugin installed `$stdout.tty?` would never return true. So I have introduced a new environment variable to force color output from the outside.

Another thing I've notice is that the colors will leak to the next line. So you'd need to put a reset ANSI code at the end of each line. But I'll have a look into that separately (maybe).

Cheers,
plu
