### PR TITLE
Align all log messgaes

### DIFF
--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -19,30 +19,35 @@ module SSHKit
 
       def write_command(command)
         unless command.started?
-          original_output << level(command.verbosity) + uuid(command) + "Running #{c.yellow(c.bold(String(command)))} #{command.host.user ? "as #{c.blue(command.host.user)}@" : "on "}#{c.blue(command.host.to_s)}\n"
+          original_output << "%6s %s\n" % [level(command.verbosity),
+                                           uuid(command) + "Running #{c.yellow(c.bold(String(command)))} #{command.host.user ? "as #{c.blue(command.host.user)}@" : "on "}#{c.blue(command.host.to_s)}"]
           if SSHKit.config.output_verbosity == Logger::DEBUG
-            original_output << level(Logger::DEBUG) + uuid(command) + "Command: #{c.blue(command.to_command)}" + "\n"
+            original_output << "%6s %s\n" % [level(Logger::DEBUG),
+                                             uuid(command) + "Command: #{c.blue(command.to_command)}"]
           end
         end
 
         if SSHKit.config.output_verbosity == Logger::DEBUG
           unless command.stdout.empty?
             command.stdout.lines.each do |line|
-              original_output << level(Logger::DEBUG) + uuid(command) + c.green("\t" + line)
+              original_output << "%6s %s" % [level(Logger::DEBUG),
+                                             uuid(command) + c.green("\t" + line)]
               original_output << "\n" unless line[-1] == "\n"
             end
           end
 
           unless command.stderr.empty?
             command.stderr.lines.each do |line|
-              original_output << level(Logger::DEBUG) + uuid(command) + c.red("\t" + line)
+              original_output << "%6s %s" % [level(Logger::DEBUG),
+                                             uuid(command) + c.red("\t" + line)]
               original_output << "\n" unless line[-1] == "\n"
             end
           end
         end
 
         if command.finished?
-          original_output << level(command.verbosity) + uuid(command) + "Finished in #{sprintf('%5.3f seconds', command.runtime)} with exit status #{command.exit_status} (#{c.bold { command.failure? ? c.red('failed') : c.green('successful') }}).\n"
+          original_output << "%6s %s\n" % [level(command.verbosity),
+                                           uuid(command) + "Finished in #{sprintf('%5.3f seconds', command.runtime)} with exit status #{command.exit_status} (#{c.bold { command.failure? ? c.red('failed') : c.green('successful') }})."]
         end
       end
 


### PR DESCRIPTION
This pull tried to complete changes introduced by 31281ed33f7ec15c7517367f3b8bf2bb6943eb90. Referenced commit adds useful pretty padding for regular log messages, but not for messages about execution particular commands.
