### PR TITLE
Simplify SSHKit::Runner::ExecuteError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ appear at the top.
     were ignored.
   * Fixed race condition where output of failed command would be empty. @townsen
     Caused random failures of `test_execute_raises_on_non_zero_exit_status_and_captures_stdout_and_stderr`
+  * Remove override of backtrace() and backtrace_locations() from ExecuteError. @townsen
+    This interferes with rake default behaviour and creates duplicate stacktraces.
 
 ## 1.6.0
 

--- a/lib/sshkit/exception.rb
+++ b/lib/sshkit/exception.rb
@@ -8,14 +8,6 @@ module SSHKit
           def initialize cause
             @cause = cause
           end
-
-          def backtrace
-            @cause.backtrace
-          end
- 
-          def backtrace_locations
-            @cause.backtrace_locations
-          end
         end
     end
 end


### PR DESCRIPTION
Remove backtrace() and backtrace_locations() overrides from
ExecuteError.  Having this interferes with rake default behaviour for
displaying exceptions with causes and creates duplicate and
unnecessarily verbose stacktraces in Capistrano.