### PR TITLE
Fixed documentation

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -44,10 +44,10 @@ end
 ```ruby
 on hosts do |host|
   f = '/some/file'
-  if test("[ -d #{f} ]")
-    execute :touch, f
-  else
+  if test("[ -f #{f} ]")
     info "#{f} already exists on #{host}!"
+  else
+    execute :touch, f
   end
 end
 ```


### PR DESCRIPTION
Parameter -d  return true value if path exists and is a directory. So for file we should use -f.
[ -f /some/file ] returns true when file exists, so statement branches should be switched.