### PR TITLE
Add transparent support for old and new colorize gem API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ appear at the top.
 
 ## (Unreleased)
 
+  * Add transparent support for old and new colorize gem API @sponomarev
   * Add your entries here, remember to credit yourself however you want to be
     credited!
   * Remove strip from capture to preserve whitespace. Nick Townsend

--- a/lib/core_ext/string.rb
+++ b/lib/core_ext/string.rb
@@ -1,0 +1,6 @@
+require 'colorize'
+
+class String
+  COLORS = color_codes unless defined?(COLORS)
+  MODES = mode_codes unless defined?(MODES)
+end

--- a/lib/sshkit/all.rb
+++ b/lib/sshkit/all.rb
@@ -1,5 +1,6 @@
 require_relative '../core_ext/array'
 require_relative '../core_ext/hash'
+require_relative '../core_ext/string'
 
 require_relative 'host'
 


### PR DESCRIPTION
Issued in #151 
