### PR TITLE
Use colorize dedicated method for color and modes

### DIFF
--- a/lib/sshkit/color.rb
+++ b/lib/sshkit/color.rb
@@ -1,7 +1,7 @@
 require 'colorize'
 
 module Color
-  String::COLORS.each_pair do |color, _|
+  String.colors.each do |color|
     instance_eval <<-RUBY, __FILE__, __LINE__
       def #{color}(string = '')
         string = yield if block_given?
@@ -10,7 +10,7 @@ module Color
     RUBY
   end
 
-  String::MODES.each_pair do |mode, _|
+  String.modes.each do |mode|
     instance_eval <<-RUBY, __FILE__, __LINE__
       def #{mode}(string = '')
         string = yield if block_given?


### PR DESCRIPTION
Hey, colorize gem provides dedicated methods to list all modes and colors.
This merge request fix this problem.
