### PR TITLE
Allow running local commands using `on(:local)`

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -344,3 +344,10 @@ Replace `on` with `run_locally`
       end
     end
 
+You can achieve the same thing with `on(:local)`
+
+    on(:local) do
+      within '/tmp' do
+        execute :whoami
+      end
+    end

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'fileutils'
 module SSHKit
 
   module Backend
@@ -29,6 +30,26 @@ module SSHKit
       def capture(*args)
         options = { verbosity: Logger::DEBUG }.merge(args.extract_options!)
         _execute(*[*args, options]).full_stdout
+      end
+
+      def upload!(local, remote, options = {})
+        if local.is_a?(String)
+          FileUtils.cp(local, remote)
+        else
+          File.open(remote, "wb") do |f|
+            IO.copy_stream(local, f)
+          end
+        end
+      end
+
+      def download!(remote, local=nil, options = {})
+        if local.nil?
+          FileUtils.cp(remote, File.basename(remote))
+        else
+          File.open(remote, "rb") do |f|
+            IO.copy_stream(f, local)
+          end
+        end
       end
 
       private

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -6,12 +6,12 @@ module SSHKit
     class Local < Printer
 
       def initialize(&block)
-        @host = Host.new(hostname: 'localhost') # just for logging
+        @host = Host.new(:local) # just for logging
         @block = block
       end
 
       def run
-        instance_exec(&@block)
+        instance_exec(@host, &@block)
       end
 
       def test(*args)

--- a/lib/sshkit/host.rb
+++ b/lib/sshkit/host.rb
@@ -1,4 +1,5 @@
 require 'ostruct'
+require 'etc'
 
 module SSHKit
 
@@ -22,7 +23,11 @@ module SSHKit
 
     def initialize(host_string_or_options_hash)
 
-      unless host_string_or_options_hash.is_a?(Hash)
+      if host_string_or_options_hash == :local
+        @local = true
+        @hostname = "localhost"
+        @user = Etc.getpwuid.name
+      elsif !host_string_or_options_hash.is_a?(Hash)
         suitable_parsers = [
           SimpleHostParser,
           HostWithPortParser,
@@ -49,6 +54,10 @@ module SSHKit
           end
         end
       end
+    end
+
+    def local?
+      @local
     end
 
     def hash

--- a/lib/sshkit/runners/abstract.rb
+++ b/lib/sshkit/runners/abstract.rb
@@ -15,7 +15,11 @@ module SSHKit
       private
 
       def backend(host, &block)
-        SSHKit.config.backend.new(host, &block)
+        if host.local?
+          SSHKit::Backend::Local.new(&block)
+        else
+          SSHKit.config.backend.new(host, &block)
+        end
       end
 
     end

--- a/test/unit/test_host.rb
+++ b/test/unit/test_host.rb
@@ -1,4 +1,5 @@
 require 'helper'
+require 'etc'
 
 module SSHKit
 
@@ -39,6 +40,14 @@ module SSHKit
       assert_equal 123,           h.port
       assert_equal 'user',        h.username
       assert_equal 'example.com', h.hostname
+    end
+
+    def test_host_local
+      h = Host.new :local
+      assert       h.local?
+      assert_nil   h.port
+      assert_equal Etc.getpwuid.name, h.username
+      assert_equal 'localhost',       h.hostname
     end
 
     def test_does_not_confuse_ipv6_hosts_with_port_specification


### PR DESCRIPTION
This pull request allows `on(:local)` to work as an alias for `run_locally`. The advantage of this feature is that Capistrano can be easily configured to perform actions on the local host or on a server, depending on user input, without having to replace all `on` calls with `run_locally`.

For example (in Capistrano):

    if ENV['RUN_LOCALLY']
      server :local, :roles => [:app]
    else
      server "example.com", :roles => [:app]
    end

    on roles(:app) do
      execute :any_command
    end

It also makes `download!` and `upload!` work when run locally.