### PR TITLE
introduce SSHKit.config.local_backend configuration

### DIFF
--- a/lib/sshkit/all.rb
+++ b/lib/sshkit/all.rb
@@ -30,6 +30,7 @@ require_relative 'backends/abstract'
 require_relative 'backends/connection_pool'
 require_relative 'backends/printer'
 require_relative 'backends/netssh'
+require_relative 'backends/local_printer'
 require_relative 'backends/local'
 require_relative 'backends/skipper'
 

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -1,19 +1,12 @@
 require 'open3'
 require 'fileutils'
+require 'sshkit/backends/local_printer'
+
 module SSHKit
 
   module Backend
 
-    class Local < Printer
-
-      def initialize(&block)
-        @host = Host.new(:local) # just for logging
-        @block = block
-      end
-
-      def run
-        instance_exec(@host, &@block)
-      end
+    class Local < LocalPrinter
 
       def test(*args)
         options = args.extract_options!.merge(

--- a/lib/sshkit/backends/local_printer.rb
+++ b/lib/sshkit/backends/local_printer.rb
@@ -1,0 +1,17 @@
+require 'open3'
+require 'fileutils'
+module SSHKit
+
+  module Backend
+    class LocalPrinter < Printer
+      def initialize(&block)
+        @host = Host.new(:local) # just for logging
+        @block = block
+      end
+
+      def run
+        instance_exec(@host, &@block)
+      end
+    end
+  end
+end

--- a/lib/sshkit/configuration.rb
+++ b/lib/sshkit/configuration.rb
@@ -3,7 +3,7 @@ module SSHKit
   class Configuration
 
     attr_accessor :umask, :output_verbosity
-    attr_writer :output, :backend, :default_env
+    attr_writer :output, :backend, :local_backend, :default_env
 
     def output
       @output ||= formatter(:pretty)
@@ -15,6 +15,10 @@ module SSHKit
 
     def backend
       @backend ||= SSHKit::Backend::Netssh
+    end
+
+    def local_backend
+      @local_backend ||= SSHKit::Backend::Local
     end
 
     def output_verbosity

--- a/lib/sshkit/dsl.rb
+++ b/lib/sshkit/dsl.rb
@@ -7,7 +7,7 @@ module SSHKit
     end
 
     def run_locally(&block)
-      Backend::Local.new(&block).run
+      SSHKit.config.local_backend.new(&block).run
     end
 
   end

--- a/test/unit/backends/test_local.rb
+++ b/test/unit/backends/test_local.rb
@@ -1,15 +1,12 @@
 require 'helper'
+require_relative 'test_local_printer'
 
 module SSHKit
   module Backend
-    class TestLocal < UnitTest
+    class TestLocal < TestLocalPrinter
 
       def local
         @local ||= Local.new
-      end
-
-      def test_host
-        assert_equal 'localhost', local.host.to_s
       end
 
       def test_execute

--- a/test/unit/backends/test_local_printer.rb
+++ b/test/unit/backends/test_local_printer.rb
@@ -1,0 +1,22 @@
+require 'helper'
+
+module SSHKit
+  module Backend
+    class TestLocalPrinter < UnitTest
+
+      def local
+        @local ||= LocalPrinter.new
+      end
+
+      def test_host
+        assert_equal 'localhost', local.host.to_s
+      end
+
+      def test_execute
+        assert local.execute('uname -a')
+        assert local.execute
+        assert local.execute('cd && pwd')
+      end
+    end
+  end
+end

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -41,6 +41,12 @@ module SSHKit
       assert_equal SSHKit::Backend::Printer, SSHKit.config.backend
     end
 
+    def test_local_backend
+      assert_equal SSHKit::Backend::Local, SSHKit.config.local_backend
+      assert SSHKit.config.local_backend = SSHKit::Backend::LocalPrinter
+      assert_equal SSHKit::Backend::LocalPrinter, SSHKit.config.local_backend
+    end
+
     def test_command_map
       assert_equal SSHKit.config.command_map.is_a?(SSHKit::CommandMap), true
 

--- a/test/unit/test_dsl.rb
+++ b/test/unit/test_dsl.rb
@@ -1,0 +1,20 @@
+require 'helper'
+require 'sshkit/dsl'
+
+module SSHKit
+
+  class TestDsl < UnitTest
+    include SSHKit::DSL
+
+    def setup
+      SSHKit.config = nil
+    end
+
+    def test_run_locally
+      SSHKit.config.expects(:local_backend).returns(Backend::Local)
+      run_locally do
+        # this gets executed
+      end
+    end
+  end
+end


### PR DESCRIPTION
* ability to switch local backend
* allows to perform dry run on local


This would allow capistrano to do following:

```ruby
SSHKit.configure do |config|
  config.backend = Capistrano.env.get(:sshkit_backend)
  config.local_backend = Capistrano.env.get(:sshkit_local_backend)
end
```

So when doing dry run, capistrano would set local backend to `LocalPrinter` instead of `Local`.
Because now same `Local` backend is used for dry run as normal run. That results in weird
effects like running deploy notifications when doing dry-run.