### PR TITLE
Require colorize version < 0.7.5

### DIFF
--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')
-  gem.add_runtime_dependency('colorize', '>= 0.7.0')
+  gem.add_runtime_dependency('colorize', ['>= 0.7.0', '< 0.7.5'])
 
   gem.add_development_dependency('minitest', ['>= 2.11.3', '< 2.12.0'])
   gem.add_development_dependency('rake')


### PR DESCRIPTION
As described in #203, upgrading to `colorize` 0.7.5 breaks something in sshkit. 

I'll admit that I haven't looked into the root cause, but I thought this might be an acceptable solution for now.