### PR TITLE
Controlling STDIN

### DIFF
--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -62,8 +62,8 @@ module SSHKit
         _execute(*[*args, options]).success?
       end
 
-      def execute(*args)
-        _execute(*args).success?
+      def execute(*args, &block)
+        _execute(*args, &block).success?
       end
 
       def background(*args)
@@ -141,6 +141,15 @@ module SSHKit
                   cmd.stdout = data
                   cmd.full_stdout += data
                   output << cmd
+
+                  if block_given?
+                    yield(cmd)
+                    input = cmd.stdin
+                    cmd.stdin = nil
+                    if input && !input.empty?
+                      ch.send_data "#{input}\n"
+                    end
+                  end
                 end
                 chan.on_extended_data do |ch, type, data|
                   cmd.stderr = data

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -15,8 +15,8 @@ module SSHKit
       execute :make, tasks
     end
 
-    def execute(command, args=[])
-      Command.new(command, args)
+    def execute(command, args=[], &block)
+      Command.new(command, args, &block)
     end
 
     private
@@ -34,7 +34,7 @@ module SSHKit
 
     attr_reader :command, :args, :options, :started_at, :started, :exit_status
 
-    attr_accessor :stdout, :stderr
+    attr_accessor :stdin, :stdout, :stderr
     attr_accessor :full_stdout, :full_stderr
 
     # Initialize a new Command object
@@ -51,6 +51,7 @@ module SSHKit
       @args    = args
       @options.symbolize_keys!
       sanitize_command!
+      @stdin = nil
       @stdout, @stderr = String.new, String.new
       @full_stdout, @full_stderr = String.new, String.new
     end


### PR DESCRIPTION
Allow calling methods that use execute to process the data returned by an ssh command and respond on stdin if needed.  One approach to addressing #216.