### PR TITLE
Do not include SSHKit::DSL in the context it is required in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This file is written in reverse chronological order, newer releases will
 appear at the top.
 
 ## `master` (Unreleased)
+  * Do not auto-include DSL in context of `require`. Load DSL with Gem and allow to include it.
+    [PR #219](https://github.com/capistrano/sshkit/pull/219)
+    @beatrichartz
   * `SSHKit::Backend::Netssh.pool.idle_timeout = 0` doesn't disable connection pooling anymore,
     only connection expiration. To disable connection polling use `SSHKit::Backend::Netssh.pool.enabled = false`
   * Add your entries below here, remember to credit yourself however you want

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -366,12 +366,14 @@ known test cases, it works. The key thing is that `if` is not mapped to
 Into the `Rakefile` simply put something like:
 
 ```ruby
-require 'sshkit/dsl'
+require 'sshkit'
 
 SSHKit.config.command_map[:rake] = "./bin/rake"
 
 desc "Deploy the site, pulls from Git, migrate the db and precompile assets, then restart Passenger."
 task :deploy do
+  include SSHKit::DSL
+
   on "example.com" do |host|
     within "/opt/sites/example.com" do
       execute :git, :pull

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The typical use-case looks something like this:
 
 ```ruby
 require 'sshkit'
-require 'sshkit/dsl'
+include SSHKit::DSL
 
 on %w{1.example.com 2.example.com}, in: :sequence, wait: 5 do |host|
   within "/opt/sites/example.com" do

--- a/lib/sshkit/all.rb
+++ b/lib/sshkit/all.rb
@@ -10,6 +10,7 @@ require_relative 'configuration'
 require_relative 'coordinator'
 
 require_relative 'deprecation_logger'
+require_relative 'dsl'
 
 require_relative 'exception'
 

--- a/lib/sshkit/dsl.rb
+++ b/lib/sshkit/dsl.rb
@@ -13,5 +13,3 @@ module SSHKit
   end
 
 end
-
-include SSHKit::DSL

--- a/test/unit/test_dsl.rb
+++ b/test/unit/test_dsl.rb
@@ -1,0 +1,26 @@
+require 'helper'
+
+module SSHKit
+
+  class TestDSL < UnitTest
+    include SSHKit::DSL
+
+    def test_dsl_on
+      coordinator = mock
+      Coordinator.stubs(:new).returns coordinator
+      coordinator.expects(:each).at_least_once
+
+      on('1.2.3.4')
+    end
+
+    def test_dsl_run_locally
+      local_backend = mock
+      Backend::Local.stubs(:new).returns local_backend
+      local_backend.expects(:run).at_least_once
+
+      run_locally
+    end
+
+  end
+
+end


### PR DESCRIPTION
In https://github.com/capistrano/sshkit/pull/28 the dsl file was removed from the original requires - I assume since the DSL was also automatically included in the context it was required in.

If I want to load the DSL _and_ use it in another context than required in, the current inclusion pattern for the DSL leaves no options - the DSL gets auto-included wherever I require it.

This leads to code like:

```ruby
require 'sskit'
module MyModule
  class ClassUsingDSL
    require 'sshkit/dsl'
    #...
  end
end
```

which is suboptimal. We can require the dsl with all other files and make the include optional instead, which allows for:

```ruby
require 'sshkit'
module MyModule
  class ClassUsingDSL
    include SSHKit::DSL
    #...
  end
end
```

The required changes are in this PR.