### PR TITLE
Fix race condition in SSH backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ appear at the top.
   * Merge host ssh_options and Netssh defaults @townsen
     Previously if host-level ssh_options were defined the Netssh defaults
     were ignored.
+  * Fixed race condition where output of failed command would be empty. @townsen
+    Caused random failures of `test_execute_raises_on_non_zero_exit_status_and_captures_stdout_and_stderr`
 
 ## 1.6.0
 

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -133,6 +133,7 @@ module SSHKit
         command(*args).tap do |cmd|
           output << cmd
           cmd.started = true
+          exit_status = nil
           with_ssh do |ssh|
             ssh.open_channel do |chan|
               chan.request_pty if Netssh.config.pty
@@ -148,9 +149,7 @@ module SSHKit
                   output << cmd
                 end
                 chan.on_request("exit-status") do |ch, data|
-                  cmd.stdout = ''
-                  cmd.stderr = ''
-                  cmd.exit_status = data.read_long
+                  exit_status = data.read_long
                   output << cmd
                 end
                 #chan.on_request("exit-signal") do |ch, data|
@@ -176,6 +175,7 @@ module SSHKit
             end
             ssh.loop
           end
+          cmd.exit_status = exit_status if exit_status
         end
       end
 


### PR DESCRIPTION
Since SSH channel events are not guaranteed to arrive in sequence, the
exit-status event could precede the extended_data event. Since raising
the exception was triggered by assigning the exit status this would
cause the output of failed command to be empty.

Also explains random failures in the test:

   `test_execute_raises_on_non_zero_exit_status_and_captures_stdout_and_stderr`