### PR TITLE
Fix duplicate messages

### DIFF
--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -34,6 +34,7 @@ module SSHKit
                                              uuid(command) + c.green("\t" + line)]
               original_output << "\n" unless line[-1] == "\n"
             end
+            command.stdout = ''
           end
 
           unless command.stderr.empty?
@@ -42,6 +43,7 @@ module SSHKit
                                              uuid(command) + c.red("\t" + line)]
               original_output << "\n" unless line[-1] == "\n"
             end
+            command.stderr = ''
           end
         end
 


### PR DESCRIPTION
Reset command stdout and stderr strings to avoid duplicate messages
Introduced by the race condition fix

Sorry about this! I didn't spot that the DEBUG messages for stdout and stderr were being duplicated..