### PR TITLE
Log command *after* setting its exit_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ appear at the top.
 
 ## `master` (Unreleased)
 
+  * Fix a regression in 1.7.0 that caused command completion messages to be removed from log output. @mattbrictson
   * Add your entries here, remember to credit yourself however you want to be
     credited!
 

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -150,7 +150,6 @@ module SSHKit
                 end
                 chan.on_request("exit-status") do |ch, data|
                   exit_status = data.read_long
-                  output << cmd
                 end
                 #chan.on_request("exit-signal") do |ch, data|
                 #  # TODO: This gets called if the program is killed by a signal
@@ -175,7 +174,11 @@ module SSHKit
             end
             ssh.loop
           end
-          cmd.exit_status = exit_status if exit_status
+          # Set exit_status and log the result upon completion
+          if exit_status
+            cmd.exit_status = exit_status
+            output << cmd
+          end
         end
       end
 


### PR DESCRIPTION
This restores SSHKit 1.6 behavior and ensures that command completion status messages appear in the log output.

Fixes #226.