### PR TITLE
Support pty or interaction handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ appear at the top.
 
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * Added support for :interaction_handler option on commands. @robd
+  * Removed partially supported 'trace' log level. @robd
   * No longer strip whitespace or newlines in `capture` method on Netssh backend. @robd
-    * This is to make the `Local` and `Netssh` backends consistent (they diverged at 7d15a9a)    
-    * If you need the old behaviour back, call `.strip` (or `.chomp`) on the captured string i.e. `capture(:my_command).strip`  
+    * This is to make the `Local` and `Netssh` backends consistent (they diverged at 7d15a9a)
+    * If you need the old behaviour back, call `.strip` (or `.chomp`) on the captured string i.e. `capture(:my_command).strip`
   * Simplified backend hierarchy. @robd
     * Moved duplicate implementations of `make`, `rake`, `test`, `capture`, `background` on to `Abstract` backend.
     * Backend implementations now only need to implement `execute_command`, `upload!` and `download!`

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -67,11 +67,11 @@ have a shell defined, one cannot switch to that user.
 ## Run a command which requires interaction between the client and the server
 
     on hosts do |host|
-      execute(:passwd, :interaction_handler => MappingInteractionHandler.new(
-        '(current) UNIX password: ' : 'old_pw',
-        'Enter new UNIX password: ' : 'new_pw',
-        'Retype new UNIX password: ' : 'new_pw',
-        'passwd: password updated successfully' : nil # Map a nil input for stdout/stderr which can be ignored
+      execute(:passwd, interaction_handler: MappingInteractionHandler.new(
+        '(current) UNIX password: ' => 'old_pw',
+        'Enter new UNIX password: ' => 'new_pw',
+        'Retype new UNIX password: ' => 'new_pw',
+        'passwd: password updated successfully' => nil # For stdout/stderr which can be ignored, map a nil input
       ))
     end
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -64,6 +64,17 @@ This will output:
 **Note:** This example is a bit misleading, as the `www-data` user doesn't
 have a shell defined, one cannot switch to that user.
 
+## Run a command which requires interaction between the client and the server
+
+    on hosts do |host|
+      execute(:passwd, :interaction_handler => MappingInteractionHandler.new(
+        '(current) UNIX password: ' : 'old_pw',
+        'Enter new UNIX password: ' : 'new_pw',
+        'Retype new UNIX password: ' : 'new_pw',
+        'passwd: password updated successfully' : nil # Map a nil input for stdout/stderr which can be ignored
+      ))
+    end
+
 ## Upload a file from disk
 
     on hosts do |host|

--- a/README.md
+++ b/README.md
@@ -239,17 +239,17 @@ end
 
 # ...
 
-execute(:passwd, :interaction_handler => PasswdInteractionHandler.new)
+execute(:passwd, interaction_handler: PasswdInteractionHandler.new)
 ```
 
 Often, you want to map directly from an output string returned by the server to the corresponding input string (as in the case above).
 For this case you can use a `MappingInteractionHandler`:
 
 ```ruby
-execute(:passwd, :interaction_handler => MappingInteractionHandler.new(
-  '(current) UNIX password: ' : 'old_pw',
-  'Enter new UNIX password: ' : 'new_pw',
-  'Retype new UNIX password: ' : 'new_pw',
+execute(:passwd, interaction_handler: MappingInteractionHandler.new(
+  '(current) UNIX password: ' => 'old_pw',
+  'Enter new UNIX password: ' => 'new_pw',
+  'Retype new UNIX password: ' => 'new_pw',
   'passwd: password updated successfully' : nil # For stdout/stderr which can be ignored, map a nil input
 ))
 ```
@@ -266,8 +266,8 @@ ENTER_PASSWORD = MappingInteractionHandler.new('Please Enter Password' : 'some_p
 
 # ...
 
-execute(:first_command,  :interaction_handler => ENTER_PASSWORD)
-execute(:second_command,  :interaction_handler => ENTER_PASSWORD)
+execute(:first_command, interaction_handler: ENTER_PASSWORD)
+execute(:second_command, interaction_handler: ENTER_PASSWORD)
 ```
 
 `:interaction_handler`s can also be stateful if you need them to be and you can capture user data with `$stdin`:
@@ -293,10 +293,10 @@ end
 
 # ...
 
-prompt_or_used_cached = PromptUserForPasswordAndCache.new
+prompt_or_use_cached = PromptUserForPasswordAndCache.new
 
-execute(:first_command, :interaction_handler => prompt_or_used_cached)
-execute(:second_command,  :interaction_handler => prompt_or_used_cached)
+execute(:first_command, interaction_handler: prompt_or_use_cached)
+execute(:second_command, interaction_handler: prompt_or_use_cached)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,119 @@ desirable.
 *Note:* All keys should be symbolised, as the *Command* object will symbolize it's
 first argument before attempting to find it in the *command map*.
 
+## Interactive commands
+> (BETA) (Added in version #.##)
+
+By default, commands against remote servers are run in a *non-login, non-interactive* ssh session.
+This is by design, to try and isolate the environment and make sure that things work as expected,
+regardless of any changes that might happen on the server side. This means that,
+although the server may have prompted you, and be waiting for it,
+**you cannot send data to the server by typing into your terminal window**.
+Wherever possible, you should call commands in a way that doesn't require interaction
+(eg by specifying all options as command arguments).
+
+However in some cases, you may want to programmatically drive interaction with a command
+and this can be achieved by specifying an `:interaction_handler` option when you `execute`, `capture` or `test` a command.
+
+**It is not necessary, or desirable to enable `Netssh.config.pty` to use the `interaction_handler` option.
+Only enable `Netssh.config.pty` if the command you are calling won't work without a pty.**
+
+An `interaction_handler` is an object which responds to `on_stdout(stdout, channel, command)` or `on_stderr(stderr, channel, command)`.
+The `interaction_handler`'s methods will be called once per line of `stdout` or `stderr` from the server and
+can send data back to the server using the `channel` parameter.
+This allows scripting of command interaction by responding to `stdout` or `stderr` lines with any input required.
+
+For example, an interaction handler to change the password of your linux user using the `passwd` command could look like this:
+
+```ruby
+class PasswdInteractionHandler
+  def on_stderr(channel, stderr, command)
+    puts stderr
+    case stderr
+      when '(current) UNIX password: '
+        channel.send_data("old_pw\n")
+      when 'Enter new UNIX password: ', 'Retype new UNIX password: '
+        channel.send_data("new_pw\n")
+      when 'passwd: password updated successfully'
+      else
+        raise "Unexpected stderr #{stderr}"
+    end
+  end
+end
+
+# ...
+
+execute(:passwd, :interaction_handler => PasswdInteractionHandler.new)
+```
+
+Often, you want to map directly from an output string returned by the server to the corresponding input string (as in the case above).
+For this case you can use a `MappingInteractionHandler`:
+
+```ruby
+execute(:passwd, :interaction_handler => MappingInteractionHandler.new(
+  '(current) UNIX password: ' : 'old_pw',
+  'Enter new UNIX password: ' : 'new_pw',
+  'Retype new UNIX password: ' : 'new_pw',
+  'passwd: password updated successfully' : nil # For stdout/stderr which can be ignored, map a nil input
+))
+```
+
+`MappingInteractionHandler`s map output from `stdout` or `stderr` using the same single map.
+If no mapping is found, a warning will show the string you need to add to your map:
+
+`Unable to find interaction handler mapping for stdout: "Server output\n" so no response was sent`
+
+`MappingInteractionHandler`s are stateless, so you can assign one to a constant and reuse it:
+
+```ruby
+ENTER_PASSWORD = MappingInteractionHandler.new('Please Enter Password' : 'some_password')
+
+# ...
+
+execute(:first_command,  :interaction_handler => ENTER_PASSWORD)
+execute(:second_command,  :interaction_handler => ENTER_PASSWORD)
+```
+
+`:interaction_handler`s can also be stateful if you need them to be and you can capture user data with `$stdin`:
+
+```ruby
+class PromptUserForPasswordAndCache
+  @password_cache = {}
+
+  def on_stderr(channel, stderr, command)
+    if data =~ /Sorry.*\stry\sagain/
+      @password_cache[command.host] = nil
+    end
+    if data =~ /password.*:/
+      pass = password_cache[command.host]
+      unless pass
+        pass = $stdin.noecho(&:gets)
+        password_cache[command.host] = pass
+      end
+      ch.send_data(pass)
+    end
+  end
+end
+
+# ...
+
+prompt_or_used_cached = PromptUserForPasswordAndCache.new
+
+execute(:first_command, :interaction_handler => prompt_or_used_cached)
+execute(:second_command,  :interaction_handler => prompt_or_used_cached)
+
+```
+
+When using the `Netssh` backend, the `channel` parameter of `on_stdout(channel, stdout, command)` or
+`on_stderr(channel, stderr, command)` is a
+[Net::SSH Channel](http://net-ssh.github.io/ssh/v2/api/classes/Net/SSH/Connection/Channel.html).
+When using the `Local` backend, it is a [ruby IO](http://ruby-doc.org/core/IO.html) object.
+If you need to support both sorts of backends with the same interaction handler,
+you need to call methods the appropriate API depending on the channel type.
+One approach is to detect the presence of the API methods you need -
+eg `channel.respond_to?(:send_data) # Net::SSH channel` and `channel.respond_to?(:write) # IO`.
+See the `MappingInteractionHandler` for an example of this.
+
 ## Output Handling
 
 ![Example Output](https://raw.github.com/leehambley/sshkit/master/examples/images/example_output.png)

--- a/lib/sshkit/all.rb
+++ b/lib/sshkit/all.rb
@@ -14,6 +14,8 @@ require_relative 'exception'
 require_relative 'logger'
 require_relative 'log_message'
 
+require_relative 'mapping_interaction_handler'
+
 require_relative 'formatters/abstract'
 require_relative 'formatters/black_hole'
 require_relative 'formatters/simple_text'

--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -6,6 +6,9 @@ module SSHKit
 
     class Abstract
 
+      extend Forwardable
+      def_delegators :output, :log, :fatal, :error, :warn, :info, :debug
+
       attr_reader :host
 
       def run
@@ -16,34 +19,6 @@ module SSHKit
         raise "Must pass a Host object" unless host.is_a? Host
         @host  = host
         @block = block
-      end
-
-      def log(messages)
-        info(messages)
-      end
-
-      def fatal(messages)
-        output << LogMessage.new(Logger::FATAL, messages)
-      end
-
-      def error(messages)
-        output << LogMessage.new(Logger::ERROR, messages)
-      end
-
-      def warn(messages)
-        output << LogMessage.new(Logger::WARN, messages)
-      end
-
-      def info(messages)
-        output << LogMessage.new(Logger::INFO, messages)
-      end
-
-      def debug(messages)
-        output << LogMessage.new(Logger::DEBUG, messages)
-      end
-
-      def trace(messages)
-        output << LogMessage.new(Logger::TRACE, messages)
       end
 
       def make(commands=[])

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -41,18 +41,14 @@ module SSHKit
         Open3.popen3(cmd.to_command) do |stdin, stdout, stderr, wait_thr|
           stdout_thread = Thread.new do
             while line = stdout.gets do
-              cmd.stdout = line
-              cmd.full_stdout += line
-
+              cmd.on_stdout(line)
               output << cmd
             end
           end
 
           stderr_thread = Thread.new do
             while line = stderr.gets do
-              cmd.stderr = line
-              cmd.full_stderr += line
-
+              cmd.on_stderr(line)
               output << cmd
             end
           end
@@ -61,8 +57,8 @@ module SSHKit
           stderr_thread.join
 
           cmd.exit_status = wait_thr.value.to_i
-          cmd.stdout = ''
-          cmd.stderr = ''
+          cmd.clear_stdout_lines
+          cmd.clear_stderr_lines
 
           output << cmd
         end

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -41,14 +41,14 @@ module SSHKit
         Open3.popen3(cmd.to_command) do |stdin, stdout, stderr, wait_thr|
           stdout_thread = Thread.new do
             while line = stdout.gets do
-              cmd.on_stdout(line)
+              cmd.on_stdout(stdin, line)
               output << cmd
             end
           end
 
           stderr_thread = Thread.new do
             while line = stderr.gets do
-              cmd.on_stderr(line)
+              cmd.on_stderr(stdin, line)
               output << cmd
             end
           end

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -89,11 +89,11 @@ module SSHKit
             chan.request_pty if Netssh.config.pty
             chan.exec cmd.to_command do |ch, success|
               chan.on_data do |ch, data|
-                cmd.on_stdout(data)
+                cmd.on_stdout(ch, data)
                 output << cmd
               end
               chan.on_extended_data do |ch, type, data|
-                cmd.on_stderr(data)
+                cmd.on_stderr(ch, data)
                 output << cmd
               end
               chan.on_request("exit-status") do |ch, data|

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -89,13 +89,11 @@ module SSHKit
             chan.request_pty if Netssh.config.pty
             chan.exec cmd.to_command do |ch, success|
               chan.on_data do |ch, data|
-                cmd.stdout = data
-                cmd.full_stdout += data
+                cmd.on_stdout(data)
                 output << cmd
               end
               chan.on_extended_data do |ch, type, data|
-                cmd.stderr = data
-                cmd.full_stderr += data
+                cmd.on_stderr(data)
                 output << cmd
               end
               chan.on_request("exit-status") do |ch, data|

--- a/lib/sshkit/backends/skipper.rb
+++ b/lib/sshkit/backends/skipper.rb
@@ -21,7 +21,6 @@ module SSHKit
       alias :fatal :info
       alias :error :info
       alias :debug :info
-      alias :trace :info
 
     end
   end

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -9,10 +9,7 @@ module SSHKit
 
     Failed = Class.new(SSHKit::StandardError)
 
-    attr_reader :command, :args, :options, :started_at, :started, :exit_status
-
-    attr_accessor :stdout, :stderr
-    attr_accessor :full_stdout, :full_stderr
+    attr_reader :command, :args, :options, :started_at, :started, :exit_status, :full_stdout, :full_stderr
 
     # Initialize a new Command object
     #
@@ -28,8 +25,7 @@ module SSHKit
       @args    = args
       @options.symbolize_keys!
       sanitize_command!
-      @stdout, @stderr = String.new, String.new
-      @full_stdout, @full_stderr = String.new, String.new
+      @stdout, @stderr, @full_stdout, @full_stderr = String.new, String.new, String.new, String.new
     end
 
     def complete?
@@ -60,8 +56,18 @@ module SSHKit
     end
     alias :failed? :failure?
 
+    def on_stdout(data)
+      @stdout = data
+      @full_stdout += data
+    end
+
     def clear_stdout_lines
       split_and_clear_stream(@stdout)
+    end
+
+    def on_stderr(data)
+      @stderr = data
+      @full_stderr += data
     end
 
     def clear_stderr_lines

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -56,18 +56,20 @@ module SSHKit
     end
     alias :failed? :failure?
 
-    def on_stdout(data)
+    def on_stdout(channel, data)
       @stdout = data
       @full_stdout += data
+      call_interaction_handler(channel, data, :on_stdout)
     end
 
     def clear_stdout_lines
       split_and_clear_stream(@stdout)
     end
 
-    def on_stderr(data)
+    def on_stderr(channel, data)
       @stderr = data
       @full_stderr += data
+      call_interaction_handler(channel, data, :on_stderr)
     end
 
     def clear_stderr_lines
@@ -222,6 +224,10 @@ module SSHKit
       stream.lines.to_a.tap { stream.clear } # Convert lines enumerable to an array for ruby 1.9
     end
 
+    def call_interaction_handler(channel, data, callback_name)
+      interaction_handler = options[:interaction_handler]
+      interaction_handler.send(callback_name, channel, data, self) if interaction_handler.respond_to?(callback_name)
+    end
   end
 
 end

--- a/lib/sshkit/formatters/abstract.rb
+++ b/lib/sshkit/formatters/abstract.rb
@@ -14,6 +14,30 @@ module SSHKit
         @original_output = oio
       end
 
+      def log(messages)
+        info(messages)
+      end
+
+      def fatal(messages)
+        write_at_log_level(Logger::FATAL, messages)
+      end
+
+      def error(messages)
+        write_at_log_level(Logger::ERROR, messages)
+      end
+
+      def warn(messages)
+        write_at_log_level(Logger::WARN, messages)
+      end
+
+      def info(messages)
+        write_at_log_level(Logger::INFO, messages)
+      end
+
+      def debug(messages)
+        write_at_log_level(Logger::DEBUG, messages)
+      end
+
       def write(obj)
         raise "Abstract formatter should not be used directly, maybe you want SSHKit::Formatter::BlackHole"
       end
@@ -23,6 +47,12 @@ module SSHKit
 
       def format_std_stream_line(line)
         ("\t" + line).chomp
+      end
+
+      private
+
+      def write_at_log_level(level, messages)
+        write(LogMessage.new(level, messages))
       end
     end
 

--- a/lib/sshkit/logger.rb
+++ b/lib/sshkit/logger.rb
@@ -1,6 +1,5 @@
 module SSHKit
   class Logger
-    TRACE = -1
     DEBUG = 0
     INFO  = 1
     WARN  = 2

--- a/lib/sshkit/mapping_interaction_handler.rb
+++ b/lib/sshkit/mapping_interaction_handler.rb
@@ -1,0 +1,33 @@
+class MappingInteractionHandler
+
+  def initialize(mapping, output=SSHKit.config.output)
+    @mapping, @output = mapping, output
+  end
+
+  def on_stdout(channel, data, command)
+    on_data(channel, data, 'stdout')
+  end
+
+  def on_stderr(channel, data, command)
+    on_data(channel, data, 'stderr')
+  end
+
+  private
+
+  def on_data(channel, data, stream_name)
+    @output.debug("Looking up response for #{stream_name} message #{data.inspect}")
+
+    @output.warn("Unable to find interaction handler mapping for #{stream_name}: #{data.inspect} so no response was sent") unless @mapping.key?(data)
+
+    unless (response_data = @mapping[data]).nil?
+      @output.debug("Sending #{response_data}")
+      if channel.respond_to?(:send_data) # Net SSH Channel
+        channel.send_data("#{response_data}\n")
+      elsif channel.respond_to?(:write) # Local IO
+        channel.write("#{response_data}\n")
+      else
+        raise 'Unable to write response data to channel - unrecognised channel type'
+      end
+    end
+  end
+end

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -44,7 +44,7 @@ module SSHKit
         captured_command_result = nil
         Local.new do
           command = 'echo Enter Data; read the_data; echo Captured $the_data;'
-          captured_command_result = capture(command, :interaction_handler => enter_data_handler)
+          captured_command_result = capture(command, interaction_handler: enter_data_handler)
         end.run
         assert_equal("Enter Data\nCaptured SOME DATA\n", captured_command_result)
       end

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -35,6 +35,19 @@ module SSHKit
         assert_equal true,  succeeded_test_result
         assert_equal false, failed_test_result
       end
+
+      def test_interaction_handler
+        enter_data_handler = MappingInteractionHandler.new(
+          "Enter Data\n" => 'SOME DATA',
+          "Captured SOME DATA\n" => nil
+        )
+        captured_command_result = nil
+        Local.new do
+          command = 'echo Enter Data; read the_data; echo Captured $the_data;'
+          captured_command_result = capture(command, :interaction_handler => enter_data_handler)
+        end.run
+        assert_equal("Enter Data\nCaptured SOME DATA\n", captured_command_result)
+      end
     end
   end
 end

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -132,7 +132,7 @@ module SSHKit
         captured_command_result = nil
         Netssh.new(a_host) do
           command = 'echo Enter Data; read the_data; echo Captured $the_data;'
-          captured_command_result = capture(command, :interaction_handler => enter_data_handler)
+          captured_command_result = capture(command, interaction_handler: enter_data_handler)
         end.run
         assert_equal("Enter Data\nCaptured SOME DATA\n", captured_command_result)
       end

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -123,6 +123,19 @@ module SSHKit
         end.run
         assert_equal File.open(file_name).read, file_contents
       end
+
+      def test_interaction_handler
+        enter_data_handler = MappingInteractionHandler.new(
+          "Enter Data\n" => 'SOME DATA',
+          "Captured SOME DATA\n" => nil
+        )
+        captured_command_result = nil
+        Netssh.new(a_host) do
+          command = 'echo Enter Data; read the_data; echo Captured $the_data;'
+          captured_command_result = capture(command, :interaction_handler => enter_data_handler)
+        end.run
+        assert_equal("Enter Data\nCaptured SOME DATA\n", captured_command_result)
+      end
     end
 
   end

--- a/test/unit/backends/test_abstract.rb
+++ b/test/unit/backends/test_abstract.rb
@@ -102,7 +102,7 @@ module SSHKit
 
         def execute_command(command)
           @executed_command = command
-          command.full_stdout = @full_stdout
+          command.on_stdout(@full_stdout) unless @full_stdout.nil?
         end
 
         def ExampleBackend.example_host

--- a/test/unit/backends/test_abstract.rb
+++ b/test/unit/backends/test_abstract.rb
@@ -102,7 +102,7 @@ module SSHKit
 
         def execute_command(command)
           @executed_command = command
-          command.on_stdout(@full_stdout) unless @full_stdout.nil?
+          command.on_stdout(nil, @full_stdout) unless @full_stdout.nil?
         end
 
         def ExampleBackend.example_host

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -23,23 +23,23 @@ module SSHKit
     end
 
     def test_logging_fatal
-      assert_log("\e[0;31;49mFATAL\e[0m Test\n", Logger::FATAL, "Test")
+      assert_equal "\e[0;31;49mFATAL\e[0m Test\n", pretty.fatal('Test')
     end
 
     def test_logging_error
-      assert_log("\e[0;31;49mERROR\e[0m Test\n", Logger::ERROR, "Test")
+      assert_equal "\e[0;31;49mERROR\e[0m Test\n", pretty.error('Test')
     end
 
     def test_logging_warn
-      assert_log("\e[0;33;49mWARN\e[0m Test\n", Logger::WARN, "Test")
+      assert_equal "\e[0;33;49mWARN\e[0m Test\n", pretty.warn('Test')
     end
 
     def test_logging_info
-      assert_log("\e[0;34;49mINFO\e[0m Test\n", Logger::INFO, "Test")
+      assert_equal "\e[0;34;49mINFO\e[0m Test\n", pretty.info('Test')
     end
 
     def test_logging_debug
-      assert_log("\e[0;30;49mDEBUG\e[0m Test\n", Logger::DEBUG, "Test")
+      assert_equal "\e[0;30;49mDEBUG\e[0m Test\n", pretty.debug('Test')
     end
 
     def test_command_lifecycle_logging
@@ -66,12 +66,5 @@ module SSHKit
       assert_equal expected_log_lines, output.split("\n")
     end
 
-    private
-
-    def assert_log(expected_output, level, message)
-      pretty << SSHKit::LogMessage.new(level, message)
-      assert_equal expected_output, output
-    end
-    
   end
 end

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -49,9 +49,9 @@ module SSHKit
       pretty << command
       command.started = true
       pretty << command
-      command.stdout = 'stdout message'
+      command.on_stdout('stdout message')
       pretty << command
-      command.stderr = 'stderr message'
+      command.on_stderr('stderr message')
       pretty << command
       command.exit_status = 0
       pretty << command

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -49,9 +49,9 @@ module SSHKit
       pretty << command
       command.started = true
       pretty << command
-      command.on_stdout('stdout message')
+      command.on_stdout(nil, 'stdout message')
       pretty << command
-      command.on_stderr('stderr message')
+      command.on_stderr(nil, 'stderr message')
       pretty << command
       command.exit_status = 0
       pretty << command

--- a/test/unit/formatters/test_simple_text.rb
+++ b/test/unit/formatters/test_simple_text.rb
@@ -50,9 +50,9 @@ module SSHKit
       pretty << command
       command.started = true
       pretty << command
-      command.stdout = 'stdout message'
+      command.on_stdout('stdout message')
       pretty << command
-      command.stderr = 'stderr message'
+      command.on_stderr('stderr message')
       pretty << command
       command.exit_status = 0
       pretty << command

--- a/test/unit/formatters/test_simple_text.rb
+++ b/test/unit/formatters/test_simple_text.rb
@@ -12,7 +12,7 @@ module SSHKit
       @_output ||= String.new
     end
 
-    def pretty
+    def simple
       @_simple ||= SSHKit::Formatter::SimpleText.new(output)
     end
 
@@ -23,23 +23,23 @@ module SSHKit
     end
 
     def test_logging_fatal
-      assert_log("Test\n", Logger::FATAL, 'Test')
+      assert_equal "Test\n", simple.fatal('Test')
     end
 
     def test_logging_error
-      assert_log(output, Logger::ERROR, 'Test')
+      assert_equal "Test\n", simple.error('Test')
     end
 
     def test_logging_warn
-      assert_log(output, Logger::WARN, 'Test')
+      assert_equal "Test\n", simple.warn('Test')
     end
 
     def test_logging_info
-      assert_log(output, Logger::INFO, 'Test')
+      assert_equal "Test\n", simple.info('Test')
     end
 
     def test_logging_debug
-      assert_log(output, Logger::DEBUG, 'Test')
+      assert_equal "Test\n", simple.debug('Test')
     end
 
     def test_command_lifecycle_logging
@@ -47,15 +47,15 @@ module SSHKit
       command.stubs(:uuid).returns('aaaaaa')
       command.stubs(:runtime).returns(1)
 
-      pretty << command
+      simple << command
       command.started = true
-      pretty << command
+      simple << command
       command.on_stdout('stdout message')
-      pretty << command
+      simple << command
       command.on_stderr('stderr message')
-      pretty << command
+      simple << command
       command.exit_status = 0
-      pretty << command
+      simple << command
 
       expected_log_lines = [
         'Running /usr/bin/env a_cmd some args on localhost',
@@ -65,13 +65,6 @@ module SSHKit
         'Finished in 1.000 seconds with exit status 0 (successful).'
       ]
       assert_equal expected_log_lines, output.split("\n")
-    end
-
-    private
-
-    def assert_log(expected_output, level, message)
-      pretty << SSHKit::LogMessage.new(level, message)
-      assert_equal expected_output, output
     end
 
   end

--- a/test/unit/formatters/test_simple_text.rb
+++ b/test/unit/formatters/test_simple_text.rb
@@ -50,9 +50,9 @@ module SSHKit
       simple << command
       command.started = true
       simple << command
-      command.on_stdout('stdout message')
+      command.on_stdout(nil, 'stdout message')
       simple << command
-      command.on_stderr('stderr message')
+      command.on_stderr(nil, 'stderr message')
       simple << command
       command.exit_status = 0
       simple << command

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -165,13 +165,13 @@ module SSHKit
 
     def test_on_stdout
       c = Command.new(:whoami)
-      c.on_stdout("test\n")
+      c.on_stdout(nil, "test\n")
       assert_equal ["test\n"], c.clear_stdout_lines
     end
 
     def test_on_stderr
       c = Command.new(:whoami)
-      c.on_stderr("test\n")
+      c.on_stderr(nil, "test\n")
       assert_equal ["test\n"], c.clear_stderr_lines
     end
 

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -163,16 +163,22 @@ module SSHKit
       assert c.failed?
     end
 
-    def test_appending_stdout
+    def test_on_stdout
       c = Command.new(:whoami)
-      assert c.stdout += "test\n"
-      assert_equal "test\n", c.stdout
+      c.on_stdout("test\n")
+      assert_equal ["test\n"], c.clear_stdout_lines
     end
 
-    def test_appending_stderr
+    def test_on_stderr
       c = Command.new(:whoami)
-      assert c.stderr += "test\n"
-      assert_equal "test\n", c.stderr
+      c.on_stderr("test\n")
+      assert_equal ["test\n"], c.clear_stderr_lines
+    end
+
+    def test_clear_lines_methods_return_empty_array_when_blank
+      command = Command.new(:some_command)
+      assert_equal [], command.clear_stdout_lines
+      assert_equal [], command.clear_stderr_lines
     end
 
     def test_setting_exit_status
@@ -197,12 +203,6 @@ module SSHKit
         Command.new(:whoami).exit_status = 1
       end
       assert_equal "whoami exit status: 1\nwhoami stdout: Nothing written\nwhoami stderr: Nothing written\n", error.message
-    end
-
-    def test_clear_lines_methods_return_empty_array_when_blank
-      command = Command.new(:some_command)
-      assert_equal [], command.clear_stdout_lines
-      assert_equal [], command.clear_stderr_lines
     end
 
   end

--- a/test/unit/test_logger.rb
+++ b/test/unit/test_logger.rb
@@ -5,7 +5,6 @@ module SSHKit
   class TestLogger < UnitTest
 
     def test_logger_severity_constants
-      assert_equal Logger::TRACE, -1
       assert_equal Logger::DEBUG,  0
       assert_equal Logger::INFO,   1
       assert_equal Logger::WARN,   2

--- a/test/unit/test_mapping_interaction_handler.rb
+++ b/test/unit/test_mapping_interaction_handler.rb
@@ -1,0 +1,39 @@
+require 'helper'
+
+module SSHKit
+
+  class TestMappingInteractionHandler < UnitTest
+    def channel
+      @channel ||= mock
+    end
+
+    def output
+      @output ||= stub(debug: anything)
+    end
+
+    def test_calls_send_data_with_mapped_input_when_stdout_matches
+      handler = MappingInteractionHandler.new({'Server output' => 'some input'}, output)
+
+      channel.expects(:send_data).with("some input\n")
+
+      handler.on_stdout(channel, 'Server output', nil)
+    end
+
+    def test_calls_send_data_with_mapped_input_when_stderr_matches
+      handler = MappingInteractionHandler.new({'Server output' => 'some input'}, output)
+
+      channel.expects(:send_data).with("some input\n")
+
+      handler.on_stderr(channel, 'Server output', nil)
+    end
+
+    def test_raises_warning_if_server_output_is_not_matched
+      handler = MappingInteractionHandler.new({}, output)
+
+      output.expects(:warn).with('Unable to find interaction handler mapping for stdout: "Server output\n" so no response was sent')
+
+      handler.on_stdout(channel, "Server output\n", nil)
+    end
+  end
+
+end


### PR DESCRIPTION
I know there has been a lot of confusion and misunderstanding around the `Netssh.config.pty` option with a lot of people (myself included - sorry!) thinking that interactive sessions are supported in SSHKit. My understanding is that full interactivity support is not a direction SSHKit should go in (I agree). So this is an attempt at implementing a minimal patch to allow users to write their own programmatic, rules-based handlers to support interactive workflows. ie 'When the server responds with x', 'send y'.

This PR adds support for an enhanced `:pty` option on `Command` in addition to the existing global level  `Netssh.config.pty` option. This `:pty` option still supports values of `true` and `false`/`nil` as before, but also now supports passing a handler object which defines `on_stdout(data, channel)` and/or `on_sterr(data, channel)`. If specified, this handler is called once per line from the server and provides the channel so that data can be written in response to particular server responses.

I do not propose to add any specific handlers to SSHKit - these could be provided by one or more external gems, but below is an example of a handler to support interactive sudo based on the [working implementation](https://github.com/kentaroi/sshkit-sudo/blob/2f1eefef53efb9f57f732159a7d75a7f26c6fc51/lib/sshkit/sudo/backends_ext/netssh.rb#L28-L37) in [ssh-sudo](https://github.com/kentaroi/sshkit-sudo):

```ruby
# The following would not be included in SSHKit, 
# but here is an example of a pty handler which supports interactive sudo

class InteractiveSudo
  def on_stdout(data, ch)
    if data =~ /Sorry.*\stry\sagain/
      @cached_password = nil
    end
    if data =~ /password.*:/
      pass = @cached_password
      unless pass
        pass = $stdin.noecho(&:gets)
        @cached_password = pass
      end
      ch.send_data(pass)
    end
  end
end

INTERACTIVE_SUDO = InteractiveSudo.new()

# Client code:

execute(:sudo, 'Some command', :pty => INTERACTIVE_SUDO)
```

As part of this work, I also formalised the mutations allowed on the `@stdout`, `@stderr`, `@full_stdout` and `@full_stderr` attributes on `Command`, and removed the writers. I have some questions around this and ideas for a bit of further cleanup / tests here too.

The test suite passes, but I didn't want to spend time adding more tests until I had some indication that this PR is desirable. As well as tests, I'd also add comprehensive docs about the interactivity support, and try to add comments to all the issues / SO questions to steer people in the right direction.

There are a number of outstanding questions, especially around local server support, but we can get into those if you're happy with the basic idea. This work was based on discussions with @kentaroi on his [ssh-sudo](https://github.com/kentaroi/sshkit-sudo) project.

EDIT: It turns out, the changes to pty are not necessary to support the basic use case of interacting with the server, so I reworked this PR see comments below for subsequent developments