### PR TITLE
Remove duplication in clearing command stdout / stderr

### DIFF
--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -83,6 +83,14 @@ module SSHKit
     end
     alias :failed? :failure?
 
+    def clear_stdout_lines
+      @stdout.lines.tap { @stdout.clear }
+    end
+
+    def clear_stderr_lines
+      @stderr.lines.tap { @stderr.clear }
+    end
+
     def exit_status=(new_exit_status)
       @finished_at = Time.now
       @exit_status = new_exit_status

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -84,11 +84,11 @@ module SSHKit
     alias :failed? :failure?
 
     def clear_stdout_lines
-      @stdout.lines.tap { @stdout.clear }
+      split_and_clear_stream(@stdout)
     end
 
     def clear_stderr_lines
-      @stderr.lines.tap { @stderr.clear }
+      split_and_clear_stream(@stderr)
     end
 
     def exit_status=(new_exit_status)
@@ -233,6 +233,10 @@ module SSHKit
           end
         end
       end
+    end
+
+    def split_and_clear_stream(stream)
+      stream.lines.to_a.tap { stream.clear } # Convert lines enumerable to an array for ruby 1.9
     end
 
   end

--- a/lib/sshkit/formatters/abstract.rb
+++ b/lib/sshkit/formatters/abstract.rb
@@ -19,6 +19,11 @@ module SSHKit
       end
       alias :<< :write
 
+      protected
+
+      def format_std_stream_line(line)
+        ("\t" + line).chomp
+      end
     end
 
   end

--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -28,22 +28,16 @@ module SSHKit
         end
 
         if SSHKit.config.output_verbosity == Logger::DEBUG
-          unless command.stdout.empty?
-            command.stdout.lines.each do |line|
-              original_output << "%6s %s" % [level(Logger::DEBUG),
-                                             uuid(command) + c.green("\t" + line)]
-              original_output << "\n" unless line[-1] == "\n"
-            end
-            command.stdout = ''
+          command.clear_stdout_lines.each do |line|
+            original_output << "%6s %s" % [level(Logger::DEBUG),
+                                           uuid(command) + c.green("\t" + line)]
+            original_output << "\n" unless line[-1] == "\n"
           end
 
-          unless command.stderr.empty?
-            command.stderr.lines.each do |line|
-              original_output << "%6s %s" % [level(Logger::DEBUG),
-                                             uuid(command) + c.red("\t" + line)]
-              original_output << "\n" unless line[-1] == "\n"
-            end
-            command.stderr = ''
+          command.clear_stderr_lines.each do |line|
+            original_output << "%6s %s" % [level(Logger::DEBUG),
+                                           uuid(command) + c.red("\t" + line)]
+            original_output << "\n" unless line[-1] == "\n"
           end
         end
 

--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -29,15 +29,11 @@ module SSHKit
 
         if SSHKit.config.output_verbosity == Logger::DEBUG
           command.clear_stdout_lines.each do |line|
-            original_output << "%6s %s" % [level(Logger::DEBUG),
-                                           uuid(command) + c.green("\t" + line)]
-            original_output << "\n" unless line[-1] == "\n"
+            original_output << "%6s %s\n" % [level(Logger::DEBUG), uuid(command) + c.green(format_std_stream_line(line))]
           end
 
           command.clear_stderr_lines.each do |line|
-            original_output << "%6s %s" % [level(Logger::DEBUG),
-                                           uuid(command) + c.red("\t" + line)]
-            original_output << "\n" unless line[-1] == "\n"
+            original_output << "%6s %s\n" % [level(Logger::DEBUG), uuid(command) + c.red(format_std_stream_line(line))]
           end
         end
 

--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -19,28 +19,31 @@ module SSHKit
 
       def write_command(command)
         unless command.started?
-          original_output << "%6s %s\n" % [level(command.verbosity),
-                                           uuid(command) + "Running #{c.yellow(c.bold(String(command)))} #{command.host.user ? "as #{c.blue(command.host.user)}@" : "on "}#{c.blue(command.host.to_s)}"]
+          host_prefix = command.host.user ? "as #{c.blue(command.host.user)}@" : 'on '
+          write_command_message("Running #{c.yellow(c.bold(String(command)))} #{host_prefix}#{c.blue(command.host.to_s)}", command)
           if SSHKit.config.output_verbosity == Logger::DEBUG
-            original_output << "%6s %s\n" % [level(Logger::DEBUG),
-                                             uuid(command) + "Command: #{c.blue(command.to_command)}"]
+            write_command_message("Command: #{c.blue(command.to_command)}", command, Logger::DEBUG)
           end
         end
 
         if SSHKit.config.output_verbosity == Logger::DEBUG
           command.clear_stdout_lines.each do |line|
-            original_output << "%6s %s\n" % [level(Logger::DEBUG), uuid(command) + c.green(format_std_stream_line(line))]
+            write_command_message(c.green(format_std_stream_line(line)), command, Logger::DEBUG)
           end
 
           command.clear_stderr_lines.each do |line|
-            original_output << "%6s %s\n" % [level(Logger::DEBUG), uuid(command) + c.red(format_std_stream_line(line))]
+            write_command_message(c.red(format_std_stream_line(line)), command, Logger::DEBUG)
           end
         end
 
         if command.finished?
-          original_output << "%6s %s\n" % [level(command.verbosity),
-                                           uuid(command) + "Finished in #{sprintf('%5.3f seconds', command.runtime)} with exit status #{command.exit_status} (#{c.bold { command.failure? ? c.red('failed') : c.green('successful') }})."]
+          successful_or_failed = c.bold { command.failure? ? c.red('failed') : c.green('successful') }
+          write_command_message("Finished in #{sprintf('%5.3f seconds', command.runtime)} with exit status #{command.exit_status} (#{successful_or_failed}).", command)
         end
+      end
+
+      def write_command_message(message, command, verbosity_override=nil)
+        original_output << "%6s [%s] %s\n" % [level(verbosity_override || command.verbosity), c.green(command.uuid), message]
       end
 
       def write_log_message(log_message)
@@ -49,10 +52,6 @@ module SSHKit
 
       def c
         @c ||= Color
-      end
-
-      def uuid(obj)
-        "[#{c.green(obj.uuid)}] "
       end
 
       def level(verbosity)

--- a/lib/sshkit/formatters/simple_text.rb
+++ b/lib/sshkit/formatters/simple_text.rb
@@ -32,6 +32,7 @@ module SSHKit
               original_output << "\t" + line
               original_output << "\n" unless line[-1] == "\n"
             end
+            command.stdout = ''
           end
 
           unless command.stderr.empty?
@@ -39,6 +40,7 @@ module SSHKit
               original_output << "\t" + line
               original_output << "\n" unless line[-1] == "\n"
             end
+            command.stderr = ''
           end
         end
 

--- a/lib/sshkit/formatters/simple_text.rb
+++ b/lib/sshkit/formatters/simple_text.rb
@@ -27,20 +27,14 @@ module SSHKit
         end
 
         if SSHKit.config.output_verbosity == Logger::DEBUG
-          unless command.stdout.empty?
-            command.stdout.lines.each do |line|
-              original_output << "\t" + line
-              original_output << "\n" unless line[-1] == "\n"
-            end
-            command.stdout = ''
+          command.clear_stdout_lines.each do |line|
+            original_output << "\t" + line
+            original_output << "\n" unless line[-1] == "\n"
           end
 
-          unless command.stderr.empty?
-            command.stderr.lines.each do |line|
-              original_output << "\t" + line
-              original_output << "\n" unless line[-1] == "\n"
-            end
-            command.stderr = ''
+          command.clear_stderr_lines.each do |line|
+            original_output << "\t" + line
+            original_output << "\n" unless line[-1] == "\n"
           end
         end
 

--- a/lib/sshkit/formatters/simple_text.rb
+++ b/lib/sshkit/formatters/simple_text.rb
@@ -27,14 +27,8 @@ module SSHKit
         end
 
         if SSHKit.config.output_verbosity == Logger::DEBUG
-          command.clear_stdout_lines.each do |line|
-            original_output << "\t" + line
-            original_output << "\n" unless line[-1] == "\n"
-          end
-
-          command.clear_stderr_lines.each do |line|
-            original_output << "\t" + line
-            original_output << "\n" unless line[-1] == "\n"
+          (command.clear_stdout_lines + command.clear_stderr_lines).each do |line|
+            original_output << format_std_stream_line(line) << "\n"
           end
         end
 

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -24,27 +24,27 @@ module SSHKit
 
     def test_logging_fatal
       pretty << SSHKit::LogMessage.new(Logger::FATAL, "Test")
-      assert_equal output, "\e[0;31;49mFATAL\e[0m Test\n"
+      assert_equal "\e[0;31;49mFATAL\e[0m Test\n", output
     end
 
     def test_logging_error
       pretty << SSHKit::LogMessage.new(Logger::ERROR, "Test")
-      assert_equal output, "\e[0;31;49mERROR\e[0m Test\n"
+      assert_equal "\e[0;31;49mERROR\e[0m Test\n", output
     end
 
     def test_logging_warn
       pretty << SSHKit::LogMessage.new(Logger::WARN, "Test")
-      assert_equal output, "\e[0;33;49mWARN\e[0m Test\n"
+      assert_equal "\e[0;33;49mWARN\e[0m Test\n", output
     end
 
     def test_logging_info
       pretty << SSHKit::LogMessage.new(Logger::INFO, "Test")
-      assert_equal output, "\e[0;34;49mINFO\e[0m Test\n"
+      assert_equal "\e[0;34;49mINFO\e[0m Test\n", output
     end
 
     def test_logging_debug
       pretty << SSHKit::LogMessage.new(Logger::DEBUG, "Test")
-      assert_equal output, "\e[0;30;49mDEBUG\e[0m Test\n"
+      assert_equal "\e[0;30;49mDEBUG\e[0m Test\n", output
     end
 
   end

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -23,32 +23,28 @@ module SSHKit
     end
 
     def test_logging_fatal
-      pretty << SSHKit::LogMessage.new(Logger::FATAL, "Test")
-      assert_equal "\e[0;31;49mFATAL\e[0m Test\n", output
+      assert_log("\e[0;31;49mFATAL\e[0m Test\n", Logger::FATAL, "Test")
     end
 
     def test_logging_error
-      pretty << SSHKit::LogMessage.new(Logger::ERROR, "Test")
-      assert_equal "\e[0;31;49mERROR\e[0m Test\n", output
+      assert_log("\e[0;31;49mERROR\e[0m Test\n", Logger::ERROR, "Test")
     end
 
     def test_logging_warn
-      pretty << SSHKit::LogMessage.new(Logger::WARN, "Test")
-      assert_equal "\e[0;33;49mWARN\e[0m Test\n", output
+      assert_log("\e[0;33;49mWARN\e[0m Test\n", Logger::WARN, "Test")
     end
 
     def test_logging_info
-      pretty << SSHKit::LogMessage.new(Logger::INFO, "Test")
-      assert_equal "\e[0;34;49mINFO\e[0m Test\n", output
+      assert_log("\e[0;34;49mINFO\e[0m Test\n", Logger::INFO, "Test")
     end
 
     def test_logging_debug
-      pretty << SSHKit::LogMessage.new(Logger::DEBUG, "Test")
-      assert_equal "\e[0;30;49mDEBUG\e[0m Test\n", output
+      assert_log("\e[0;30;49mDEBUG\e[0m Test\n", Logger::DEBUG, "Test")
     end
 
     def test_command_lifecycle_logging
-      command = fixed_uid_command('aaaaaa', :a_cmd, 'some args', 'localhost')
+      command = SSHKit::Command.new(:a_cmd, 'some args', host: Host.new('localhost'))
+      command.stubs(:uuid).returns('aaaaaa')
       pretty << command
       command.started = true
       pretty << command
@@ -71,10 +67,10 @@ module SSHKit
 
     private
 
-    def fixed_uid_command(constant_uuid, *args, host)
-      command = SSHKit::Command.new(*args, host: Host.new(host))
-      command.stubs(:uuid).returns(constant_uuid)
-      command
+    def assert_log(expected_output, level, message)
+      pretty << SSHKit::LogMessage.new(level, message)
+      assert_equal expected_output, output
     end
+    
   end
 end

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -47,5 +47,34 @@ module SSHKit
       assert_equal "\e[0;30;49mDEBUG\e[0m Test\n", output
     end
 
+    def test_command_lifecycle_logging
+      command = fixed_uid_command('aaaaaa', :a_cmd, 'some args', 'localhost')
+      pretty << command
+      command.started = true
+      pretty << command
+      command.stdout = 'stdout message'
+      pretty << command
+      command.stderr = 'stderr message'
+      pretty << command
+      command.exit_status = 0
+      pretty << command
+
+      expected_log_lines = [
+        "\e[0;34;49mINFO\e[0m [\e[0;32;49maaaaaa\e[0m] Running \e[1;33;49m/usr/bin/env a_cmd some args\e[0m on \e[0;34;49mlocalhost\e[0m",
+        "\e[0;30;49mDEBUG\e[0m [\e[0;32;49maaaaaa\e[0m] Command: \e[0;34;49m/usr/bin/env a_cmd some args\e[0m",
+        "\e[0;30;49mDEBUG\e[0m [\e[0;32;49maaaaaa\e[0m] \e[0;32;49m\tstdout message\e[0m",
+        "\e[0;30;49mDEBUG\e[0m [\e[0;32;49maaaaaa\e[0m] \e[0;31;49m\tstderr message\e[0m",
+        "\e[0;34;49mINFO\e[0m [\e[0;32;49maaaaaa\e[0m] Finished in 0.000 seconds with exit status 0 (\e[1;32;49msuccessful\e[0m)."
+      ]
+      assert_equal expected_log_lines, output.split("\n")
+    end
+
+    private
+
+    def fixed_uid_command(constant_uuid, *args, host)
+      command = SSHKit::Command.new(*args, host: Host.new(host))
+      command.stubs(:uuid).returns(constant_uuid)
+      command
+    end
   end
 end

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -24,27 +24,27 @@ module SSHKit
 
     def test_logging_fatal
       pretty << SSHKit::LogMessage.new(Logger::FATAL, "Test")
-      assert_equal output.strip, "\e[0;31;49mFATAL\e[0m Test"
+      assert_equal output, "\e[0;31;49mFATAL\e[0m Test\n"
     end
 
     def test_logging_error
       pretty << SSHKit::LogMessage.new(Logger::ERROR, "Test")
-      assert_equal output.strip, "\e[0;31;49mERROR\e[0m Test"
+      assert_equal output, "\e[0;31;49mERROR\e[0m Test\n"
     end
 
     def test_logging_warn
       pretty << SSHKit::LogMessage.new(Logger::WARN, "Test")
-      assert_equal output.strip, "\e[0;33;49mWARN\e[0m Test".strip
+      assert_equal output, "\e[0;33;49mWARN\e[0m Test\n"
     end
 
     def test_logging_info
       pretty << SSHKit::LogMessage.new(Logger::INFO, "Test")
-      assert_equal output.strip, "\e[0;34;49mINFO\e[0m Test".strip
+      assert_equal output, "\e[0;34;49mINFO\e[0m Test\n"
     end
 
     def test_logging_debug
       pretty << SSHKit::LogMessage.new(Logger::DEBUG, "Test")
-      assert_equal output.strip, "\e[0;30;49mDEBUG\e[0m Test".strip
+      assert_equal output, "\e[0;30;49mDEBUG\e[0m Test\n"
     end
 
   end

--- a/test/unit/formatters/test_simple_text.rb
+++ b/test/unit/formatters/test_simple_text.rb
@@ -1,0 +1,77 @@
+require 'helper'
+require 'sshkit'
+
+module SSHKit
+  class TestSimpleText < UnitTest
+
+    def setup
+      SSHKit.config.output_verbosity = Logger::DEBUG
+    end
+
+    def output
+      @_output ||= String.new
+    end
+
+    def pretty
+      @_simple ||= SSHKit::Formatter::SimpleText.new(output)
+    end
+
+    def teardown
+      remove_instance_variable :@_simple
+      remove_instance_variable :@_output
+      SSHKit.reset_configuration!
+    end
+
+    def test_logging_fatal
+      assert_log("Test\n", Logger::FATAL, 'Test')
+    end
+
+    def test_logging_error
+      assert_log(output, Logger::ERROR, 'Test')
+    end
+
+    def test_logging_warn
+      assert_log(output, Logger::WARN, 'Test')
+    end
+
+    def test_logging_info
+      assert_log(output, Logger::INFO, 'Test')
+    end
+
+    def test_logging_debug
+      assert_log(output, Logger::DEBUG, 'Test')
+    end
+
+    def test_command_lifecycle_logging
+      command = SSHKit::Command.new(:a_cmd, 'some args', host: Host.new('localhost'))
+      command.stubs(:uuid).returns('aaaaaa')
+
+      pretty << command
+      command.started = true
+      pretty << command
+      command.stdout = 'stdout message'
+      pretty << command
+      command.stderr = 'stderr message'
+      pretty << command
+      command.exit_status = 0
+      pretty << command
+
+      expected_log_lines = [
+        'Running /usr/bin/env a_cmd some args on localhost',
+        'Command: /usr/bin/env a_cmd some args',
+        "\tstdout message",
+        "\tstderr message",
+        'Finished in 0.000 seconds with exit status 0 (successful).'
+      ]
+      assert_equal expected_log_lines, output.split("\n")
+    end
+
+    private
+
+    def assert_log(expected_output, level, message)
+      pretty << SSHKit::LogMessage.new(level, message)
+      assert_equal expected_output, output
+    end
+
+  end
+end

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -199,5 +199,11 @@ module SSHKit
       assert_equal "whoami exit status: 1\nwhoami stdout: Nothing written\nwhoami stderr: Nothing written\n", error.message
     end
 
+    def test_clear_lines_methods_return_empty_array_when_blank
+      command = Command.new(:some_command)
+      assert_equal [], command.clear_stdout_lines
+      assert_equal [], command.clear_stderr_lines
+    end
+
   end
 end


### PR DESCRIPTION
This is really preparatory work for supporting pty handlers - #234

This PR grew from me not understanding why [these](https://github.com/capistrano/sshkit/blob/bcbd57f0744f5cfbe2756e779ec882645fcc0e83/lib/sshkit/formatters/pretty.rb#L37) [lines](https://github.com/capistrano/sshkit/blob/bcbd57f0744f5cfbe2756e779ec882645fcc0e83/lib/sshkit/formatters/pretty.rb#L46) that clear stdout/stderr are needed. These were added to as part of #224 to get round a duplicate messages issue, but I wanted to backfill with a failing test so I don't break it when I start fiddling with that code in #234.

I wrote a test case for the `Pretty` formatter in 61e03af which fails with duplicate messages if the clearing lines are deleted, I also noticed that there was no test at all for the `SimpleText` formatter, so I backfilled this in c13b10b. This highlighted that the duplicate messages #224 issue is not fixed for the SimpleText formatter. So I fixed this in cb06ab2. 

The remaining commits remove duplication within and between the `Pretty` and `SimpleText` formatters.

Let me know what you think - I would welcome feedback on code style and so-on.

