### PR TITLE
No longer strip whitespace/newlines in capture method on Netssh backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ appear at the top.
 
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * No longer strip whitespace or newlines in `capture` method on Netssh backend. @robd
+    * This is to make the `Local` and `Netssh` backends consistent (they diverged at 7d15a9a)    
+    * If you need the old behaviour back, call `.strip` (or `.chomp`) on the captured string i.e. `capture(:my_command).strip`  
   * Simplified backend hierarchy. @robd
     * Moved duplicate implementations of `make`, `rake`, `test`, `capture`, `background` on to `Abstract` backend.
     * Backend implementations now only need to implement `execute_command`, `upload!` and `download!`

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -28,12 +28,6 @@ module SSHKit
         end
       end
 
-      def capture(*args)
-        # The behaviour to strip the full stdout was removed from the local backend in commit 7d15a9a,
-        # but was left in for the net ssh backend.
-        super(*args).strip
-      end
-
       def upload!(local, remote, options = {})
         summarizer = transfer_summarizer('Uploading')
         with_ssh do |ssh|

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -55,8 +55,7 @@ module SSHKit
               captured_command_result = capture(:uname)
             end.run
 
-            assert captured_command_result
-            assert_match captured_command_result, /Linux|Darwin/
+            assert_includes %W(Linux\n Darwin\n), captured_command_result
           end
         end
       end
@@ -87,17 +86,17 @@ module SSHKit
         end.run
       end
 
-      def test_upload_file
-        file_contents = ""
+      def test_upload_and_then_capture_file_contents
+        actual_file_contents = ""
         file_name = File.join("/tmp", SecureRandom.uuid)
         File.open file_name, 'w+' do |f|
-          f.write 'example_file'
+          f.write "Some Content\nWith a newline and trailing spaces    \n "
         end
         Netssh.new(a_host) do
           upload!(file_name, file_name)
-          file_contents = capture(:cat, file_name)
+          actual_file_contents = capture(:cat, file_name)
         end.run
-        assert_equal "example_file", file_contents
+        assert_equal "Some Content\nWith a newline and trailing spaces    \n ", actual_file_contents
       end
 
       def test_upload_string_io


### PR DESCRIPTION
This is a breaking change, which I wanted to discuss before merging - I'm not sure what the best course of action is here.

The old `capture` behaviour was to `strip` whitespace and newlines from the captured results. I think the main reason for this was to remove trailing newlines from command results to make one liners easier to handle (eg `capture(:uname)` returns `Linux` as opposed to `Linux\n`). Unfortunately this meant that you couldn't capture command output with trailing whitespace / newlines. This was discussed in #165 with @townsen, and I believe it was decided to make this change, however this was only changed for the `Local` backend in 7d15a9a, but not for the Netssh one. I think this was an omission, so, if possible, I would like to fix this inconsistency now.

From an API (purist?) perspective, I think it makes sense to remove the `strip` method from the `Netssh` backend too as per the original decision in #165 and this PR implements that. But this might cause quite widespread breakages in client code (although easily fixed as mentioned in #165). This might mean the need for a major release version bump - I'm not sure what the policy is here.

Another option would be to revert the change made in 7d15a9a (ie put back the `strip` behaviour on `Local` backend `capture`), and introduce a new method (eg `capture_raw`) which doesn't strip. Of course the downside of this is clutter on the `Abstract` backend API which must be maintained, but this would mean that people wouldn't have to change their client code.

