### PR TITLE
Improve interaction handler api

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -80,12 +80,12 @@ have a shell defined, one cannot switch to that user.
 
 ```ruby
 on hosts do |host|
-  execute(:passwd, interaction_handler: MappingInteractionHandler.new(
+  execute(:passwd, interaction_handler: {
     '(current) UNIX password: ' => 'old_pw',
     'Enter new UNIX password: ' => 'new_pw',
     'Retype new UNIX password: ' => 'new_pw',
     'passwd: password updated successfully' => nil # For stdout/stderr which can be ignored, map a nil input
-  ))
+  })
 end
 ```
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -81,9 +81,9 @@ have a shell defined, one cannot switch to that user.
 ```ruby
 on hosts do |host|
   execute(:passwd, interaction_handler: {
-    '(current) UNIX password: ' => 'old_pw',
-    'Enter new UNIX password: ' => 'new_pw',
-    'Retype new UNIX password: ' => 'new_pw',
+    '(current) UNIX password: ' => "old_pw\n",
+    'Enter new UNIX password: ' => "new_pw\n",
+    'Retype new UNIX password: ' => "new_pw\n",
     'passwd: password updated successfully' => nil # For stdout/stderr which can be ignored, map a nil input
   })
 end

--- a/README.md
+++ b/README.md
@@ -243,19 +243,19 @@ execute(:passwd, interaction_handler: PasswdInteractionHandler.new)
 ```
 
 Often, you want to map directly from an output string returned by the server to the corresponding input string (as in the case above).
-For this case you can use a `SSHKit::MappingInteractionHandler`:
+For this case you can pass a hash which is used to create a `SSHKit::MappingInteractionHandler`:
 
 ```ruby
-execute(:passwd, interaction_handler: SSHKit::MappingInteractionHandler.new(
+execute(:passwd, interaction_handler: {
   '(current) UNIX password: ' => 'old_pw',
   'Enter new UNIX password: ' => 'new_pw',
   'Retype new UNIX password: ' => 'new_pw',
   'passwd: password updated successfully' => nil # For stdout/stderr which can be ignored, map a nil input
-))
+})
 ```
 
-`MappingInteractionHandler`s map output from `stdout` or `stderr` using the same single map.
-If no mapping is found, a warning will show the string you need to add to your map:
+`MappingInteractionHandler`s map output from `stdout` or `stderr` using the same single hash passed in the constructor.
+If no mapping is found, a warning will show the string you need to add to your hash:
 
 `Unable to find interaction handler mapping for stdout: "Server output\n" so no response was sent`
 

--- a/README.md
+++ b/README.md
@@ -243,14 +243,14 @@ execute(:passwd, interaction_handler: PasswdInteractionHandler.new)
 ```
 
 Often, you want to map directly from an output string returned by the server to the corresponding input string (as in the case above).
-For this case you can use a `MappingInteractionHandler`:
+For this case you can use a `SSHKit::MappingInteractionHandler`:
 
 ```ruby
-execute(:passwd, interaction_handler: MappingInteractionHandler.new(
+execute(:passwd, interaction_handler: SSHKit::MappingInteractionHandler.new(
   '(current) UNIX password: ' => 'old_pw',
   'Enter new UNIX password: ' => 'new_pw',
   'Retype new UNIX password: ' => 'new_pw',
-  'passwd: password updated successfully' : nil # For stdout/stderr which can be ignored, map a nil input
+  'passwd: password updated successfully' => nil # For stdout/stderr which can be ignored, map a nil input
 ))
 ```
 
@@ -262,7 +262,7 @@ If no mapping is found, a warning will show the string you need to add to your m
 `MappingInteractionHandler`s are stateless, so you can assign one to a constant and reuse it:
 
 ```ruby
-ENTER_PASSWORD = MappingInteractionHandler.new('Please Enter Password' : 'some_password')
+ENTER_PASSWORD = SSHKit::MappingInteractionHandler.new('Please Enter Password' => 'some_password')
 
 # ...
 
@@ -308,7 +308,7 @@ If you need to support both sorts of backends with the same interaction handler,
 you need to call methods the appropriate API depending on the channel type.
 One approach is to detect the presence of the API methods you need -
 eg `channel.respond_to?(:send_data) # Net::SSH channel` and `channel.respond_to?(:write) # IO`.
-See the `MappingInteractionHandler` for an example of this.
+See the `SSHKit::MappingInteractionHandler` for an example of this.
 
 ## Output Handling
 

--- a/README.md
+++ b/README.md
@@ -247,9 +247,9 @@ For this case you can pass a hash which is used to create a `SSHKit::MappingInte
 
 ```ruby
 execute(:passwd, interaction_handler: {
-  '(current) UNIX password: ' => 'old_pw',
-  'Enter new UNIX password: ' => 'new_pw',
-  'Retype new UNIX password: ' => 'new_pw',
+  '(current) UNIX password: ' => "old_pw\n",
+  'Enter new UNIX password: ' => "new_pw\n",
+  'Retype new UNIX password: ' => "new_pw\n",
   'passwd: password updated successfully' => nil # For stdout/stderr which can be ignored, map a nil input
 })
 ```
@@ -262,7 +262,7 @@ If no mapping is found, a warning will show the string you need to add to your h
 `MappingInteractionHandler`s are stateless, so you can assign one to a constant and reuse it:
 
 ```ruby
-ENTER_PASSWORD = SSHKit::MappingInteractionHandler.new('Please Enter Password' => 'some_password')
+ENTER_PASSWORD = SSHKit::MappingInteractionHandler.new('Please Enter Password' => "some_password\n")
 
 # ...
 

--- a/README.md
+++ b/README.md
@@ -242,27 +242,62 @@ end
 execute(:passwd, interaction_handler: PasswdInteractionHandler.new)
 ```
 
-Often, you want to map directly from an output string returned by the server to the corresponding input string (as in the case above).
-For this case you can pass a hash which is used to create a `SSHKit::MappingInteractionHandler`:
+Often, you want to map directly from an output string returned by the server on either stdout or stderr to the corresponding input string
+(as in the case above). For this case you can pass a hash which is used to create a `SSHKit::MappingInteractionHandler`.
+This provides similar functionality to the linux [expect](http://expect.sourceforge.net/) library:
 
 ```ruby
 execute(:passwd, interaction_handler: {
   '(current) UNIX password: ' => "old_pw\n",
-  'Enter new UNIX password: ' => "new_pw\n",
-  'Retype new UNIX password: ' => "new_pw\n",
-  'passwd: password updated successfully' => nil # For stdout/stderr which can be ignored, map a nil input
+  /(Enter|Retype) new UNIX password: / => "new_pw\n"
 })
 ```
 
-`MappingInteractionHandler`s map output from `stdout` or `stderr` using the same single hash passed in the constructor.
-If no mapping is found, a warning will show the string you need to add to your hash:
+Note the key to the hash keys are matched output using the case equals `===` method.
+This means that regexes and any objects which define `===` can be used as hash keys.
 
-`Unable to find interaction handler mapping for stdout: "Server output\n" so no response was sent`
+Hash keys are matched in order, which allows for default wildcard matches:
+
+```ruby
+execute(:my_command, interaction_handler: {
+  "some specific line\n" => "specific input\n",
+  /.*/ => "default input\n"
+})
+```
+
+You can also pass a Proc object to map the output line from the server:
+
+```ruby
+execute(:passwd, interaction_handler: lambda { |server_ouput|
+  case server_ouput
+  when '(current) UNIX password: '
+    "old_pw\n",
+  when /(Enter|Retype) new UNIX password: /
+    "new_pw\n"
+  end
+})
+```
+
+If no mapping is found, a debug message will show the string you need to add to your hash.
+This can be helpful if you don't know exactly what the server is sending back (whitespace, newlines etc),
+because you can start with a blank mapping and iteratively add messages as required:
+
+```ruby
+  # Start with this and run your script
+  execute(:unfamiliar_command, {})
+  # DEBUG log => Unable to find interaction handler mapping for stdout:
+  #              "Please type your input:\r\n" so no response was sent"
+
+  # Update mapping:
+  execute(:unfamiliar_command, {"Please type your input:\r\n" => "Some input\n"})
+```
 
 `MappingInteractionHandler`s are stateless, so you can assign one to a constant and reuse it:
 
 ```ruby
-ENTER_PASSWORD = SSHKit::MappingInteractionHandler.new('Please Enter Password' => "some_password\n")
+ENTER_PASSWORD = SSHKit::MappingInteractionHandler.new(
+  "Please Enter Password\n" => "some_password\n"
+)
 
 # ...
 

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -226,6 +226,7 @@ module SSHKit
 
     def call_interaction_handler(channel, data, callback_name)
       interaction_handler = options[:interaction_handler]
+      interaction_handler = MappingInteractionHandler.new(interaction_handler) if interaction_handler.kind_of?(Hash)
       interaction_handler.send(callback_name, channel, data, self) if interaction_handler.respond_to?(callback_name)
     end
   end

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -63,7 +63,7 @@ module SSHKit
     end
 
     def clear_stdout_lines
-      split_and_clear_stream(@stdout)
+      split_and_clear_stream(:@stdout)
     end
 
     def on_stderr(channel, data)
@@ -73,7 +73,7 @@ module SSHKit
     end
 
     def clear_stderr_lines
-      split_and_clear_stream(@stderr)
+      split_and_clear_stream(:@stderr)
     end
 
     def exit_status=(new_exit_status)
@@ -220,8 +220,9 @@ module SSHKit
       end
     end
 
-    def split_and_clear_stream(stream)
-      stream.lines.to_a.tap { stream.clear } # Convert lines enumerable to an array for ruby 1.9
+    def split_and_clear_stream(stream_name)
+      # Convert lines enumerable to an array for ruby 1.9
+      instance_variable_get(stream_name).lines.to_a.tap { instance_variable_set(stream_name, '') }
     end
 
     def call_interaction_handler(channel, data, callback_name)

--- a/lib/sshkit/mapping_interaction_handler.rb
+++ b/lib/sshkit/mapping_interaction_handler.rb
@@ -24,11 +24,11 @@ module SSHKit
       output.warn("Unable to find interaction handler mapping for #{stream_name}: #{data.inspect} so no response was sent") unless @mapping.key?(data)
 
       unless (response_data = @mapping[data]).nil?
-        output.debug("Sending #{response_data}")
+        output.debug("Sending #{response_data.inspect}")
         if channel.respond_to?(:send_data) # Net SSH Channel
-          channel.send_data("#{response_data}\n")
+          channel.send_data(response_data)
         elsif channel.respond_to?(:write) # Local IO
-          channel.write("#{response_data}\n")
+          channel.write(response_data)
         else
           raise 'Unable to write response data to channel - unrecognised channel type'
         end

--- a/lib/sshkit/mapping_interaction_handler.rb
+++ b/lib/sshkit/mapping_interaction_handler.rb
@@ -3,7 +3,17 @@ module SSHKit
   class MappingInteractionHandler
 
     def initialize(mapping)
-      @mapping = mapping
+      @mapping_proc = case mapping
+        when Hash
+          lambda do |server_output|
+            first_matching_key_value = mapping.find { |k, _v| k === server_output }
+            first_matching_key_value.nil? ? nil : first_matching_key_value.last
+          end
+        when Proc
+          mapping
+        else
+          raise "Unsupported mapping type: #{mapping.class} - only Hash and Proc mappings are supported"
+      end
     end
 
     def on_stdout(channel, data, command)
@@ -21,16 +31,18 @@ module SSHKit
 
       output.debug("Looking up response for #{stream_name} message #{data.inspect}")
 
-      output.warn("Unable to find interaction handler mapping for #{stream_name}: #{data.inspect} so no response was sent") unless @mapping.key?(data)
+      response_data = @mapping_proc.call(data)
 
-      unless (response_data = @mapping[data]).nil?
+      if response_data.nil?
+        output.debug("Unable to find interaction handler mapping for #{stream_name}: #{data.inspect} so no response was sent")
+      else
         output.debug("Sending #{response_data.inspect}")
         if channel.respond_to?(:send_data) # Net SSH Channel
           channel.send_data(response_data)
         elsif channel.respond_to?(:write) # Local IO
           channel.write(response_data)
         else
-          raise 'Unable to write response data to channel - unrecognised channel type'
+          raise "Unable to write response data to channel #{channel.inspect} - does not support 'send_data' or 'write'"
         end
       end
     end

--- a/lib/sshkit/mapping_interaction_handler.rb
+++ b/lib/sshkit/mapping_interaction_handler.rb
@@ -2,8 +2,8 @@ module SSHKit
 
   class MappingInteractionHandler
 
-    def initialize(mapping, output=SSHKit.config.output)
-      @mapping, @output = mapping, output
+    def initialize(mapping)
+      @mapping = mapping
     end
 
     def on_stdout(channel, data, command)
@@ -17,12 +17,14 @@ module SSHKit
     private
 
     def on_data(channel, data, stream_name)
-      @output.debug("Looking up response for #{stream_name} message #{data.inspect}")
+      output = SSHKit.config.output
 
-      @output.warn("Unable to find interaction handler mapping for #{stream_name}: #{data.inspect} so no response was sent") unless @mapping.key?(data)
+      output.debug("Looking up response for #{stream_name} message #{data.inspect}")
+
+      output.warn("Unable to find interaction handler mapping for #{stream_name}: #{data.inspect} so no response was sent") unless @mapping.key?(data)
 
       unless (response_data = @mapping[data]).nil?
-        @output.debug("Sending #{response_data}")
+        output.debug("Sending #{response_data}")
         if channel.respond_to?(:send_data) # Net SSH Channel
           channel.send_data("#{response_data}\n")
         elsif channel.respond_to?(:write) # Local IO

--- a/lib/sshkit/mapping_interaction_handler.rb
+++ b/lib/sshkit/mapping_interaction_handler.rb
@@ -1,33 +1,38 @@
-class MappingInteractionHandler
+module SSHKit
 
-  def initialize(mapping, output=SSHKit.config.output)
-    @mapping, @output = mapping, output
-  end
+  class MappingInteractionHandler
 
-  def on_stdout(channel, data, command)
-    on_data(channel, data, 'stdout')
-  end
+    def initialize(mapping, output=SSHKit.config.output)
+      @mapping, @output = mapping, output
+    end
 
-  def on_stderr(channel, data, command)
-    on_data(channel, data, 'stderr')
-  end
+    def on_stdout(channel, data, command)
+      on_data(channel, data, 'stdout')
+    end
 
-  private
+    def on_stderr(channel, data, command)
+      on_data(channel, data, 'stderr')
+    end
 
-  def on_data(channel, data, stream_name)
-    @output.debug("Looking up response for #{stream_name} message #{data.inspect}")
+    private
 
-    @output.warn("Unable to find interaction handler mapping for #{stream_name}: #{data.inspect} so no response was sent") unless @mapping.key?(data)
+    def on_data(channel, data, stream_name)
+      @output.debug("Looking up response for #{stream_name} message #{data.inspect}")
 
-    unless (response_data = @mapping[data]).nil?
-      @output.debug("Sending #{response_data}")
-      if channel.respond_to?(:send_data) # Net SSH Channel
-        channel.send_data("#{response_data}\n")
-      elsif channel.respond_to?(:write) # Local IO
-        channel.write("#{response_data}\n")
-      else
-        raise 'Unable to write response data to channel - unrecognised channel type'
+      @output.warn("Unable to find interaction handler mapping for #{stream_name}: #{data.inspect} so no response was sent") unless @mapping.key?(data)
+
+      unless (response_data = @mapping[data]).nil?
+        @output.debug("Sending #{response_data}")
+        if channel.respond_to?(:send_data) # Net SSH Channel
+          channel.send_data("#{response_data}\n")
+        elsif channel.respond_to?(:write) # Local IO
+          channel.write("#{response_data}\n")
+        else
+          raise 'Unable to write response data to channel - unrecognised channel type'
+        end
       end
     end
+
   end
+
 end

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -41,7 +41,7 @@ module SSHKit
         Local.new do
           command = 'echo Enter Data; read the_data; echo Captured $the_data;'
           captured_command_result = capture(command, interaction_handler: {
-            "Enter Data\n" => 'SOME DATA',
+            "Enter Data\n" => "SOME DATA\n",
             "Captured SOME DATA\n" => nil
           })
         end.run

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -37,7 +37,7 @@ module SSHKit
       end
 
       def test_interaction_handler
-        enter_data_handler = MappingInteractionHandler.new(
+        enter_data_handler = SSHKit::MappingInteractionHandler.new(
           "Enter Data\n" => 'SOME DATA',
           "Captured SOME DATA\n" => nil
         )

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -37,14 +37,13 @@ module SSHKit
       end
 
       def test_interaction_handler
-        enter_data_handler = SSHKit::MappingInteractionHandler.new(
-          "Enter Data\n" => 'SOME DATA',
-          "Captured SOME DATA\n" => nil
-        )
         captured_command_result = nil
         Local.new do
           command = 'echo Enter Data; read the_data; echo Captured $the_data;'
-          captured_command_result = capture(command, interaction_handler: enter_data_handler)
+          captured_command_result = capture(command, interaction_handler: {
+            "Enter Data\n" => 'SOME DATA',
+            "Captured SOME DATA\n" => nil
+          })
         end.run
         assert_equal("Enter Data\nCaptured SOME DATA\n", captured_command_result)
       end

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -125,14 +125,13 @@ module SSHKit
       end
 
       def test_interaction_handler
-        enter_data_handler = SSHKit::MappingInteractionHandler.new(
-          "Enter Data\n" => 'SOME DATA',
-          "Captured SOME DATA\n" => nil
-        )
         captured_command_result = nil
         Netssh.new(a_host) do
           command = 'echo Enter Data; read the_data; echo Captured $the_data;'
-          captured_command_result = capture(command, interaction_handler: enter_data_handler)
+          captured_command_result = capture(command, interaction_handler: {
+            "Enter Data\n" => 'SOME DATA',
+            "Captured SOME DATA\n" => nil
+          })
         end.run
         assert_equal("Enter Data\nCaptured SOME DATA\n", captured_command_result)
       end

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -129,7 +129,7 @@ module SSHKit
         Netssh.new(a_host) do
           command = 'echo Enter Data; read the_data; echo Captured $the_data;'
           captured_command_result = capture(command, interaction_handler: {
-            "Enter Data\n" => 'SOME DATA',
+            "Enter Data\n" => "SOME DATA\n",
             "Captured SOME DATA\n" => nil
           })
         end.run

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -125,7 +125,7 @@ module SSHKit
       end
 
       def test_interaction_handler
-        enter_data_handler = MappingInteractionHandler.new(
+        enter_data_handler = SSHKit::MappingInteractionHandler.new(
           "Enter Data\n" => 'SOME DATA',
           "Captured SOME DATA\n" => nil
         )

--- a/test/unit/test_mapping_interaction_handler.rb
+++ b/test/unit/test_mapping_interaction_handler.rb
@@ -21,19 +21,74 @@ module SSHKit
     end
 
     def test_calls_send_data_with_mapped_input_when_stderr_matches
-      handler = MappingInteractionHandler.new('Server output' => "some input\n")
-
       channel.expects(:send_data).with("some input\n")
 
-      handler.on_stderr(channel, 'Server output', nil)
+      MappingInteractionHandler.new('Server output' => "some input\n").on_stderr(channel, 'Server output', nil)
     end
 
     def test_raises_warning_if_server_output_is_not_matched
-      handler = MappingInteractionHandler.new({})
+      @output.expects(:debug).with('Unable to find interaction handler mapping for stdout: "Server output\n" so no response was sent')
 
-      @output.expects(:warn).with('Unable to find interaction handler mapping for stdout: "Server output\n" so no response was sent')
+      MappingInteractionHandler.new({}).on_stdout(channel, "Server output\n", nil)
+    end
 
-      handler.on_stdout(channel, "Server output\n", nil)
+    def test_does_not_warn_for_supports_mapping_to_nil
+      MappingInteractionHandler.new({"Some output\n" => nil}).on_stdout(channel, "Some output\n", nil)
+    end
+
+    def test_supports_regex_keys
+      channel.expects(:send_data).with("Input\n")
+
+      MappingInteractionHandler.new({ /Some \w+ output\n/ => "Input\n"}).on_stdout(channel, "Some lovely output\n", nil)
+    end
+
+    def test_supports_lambda_mapping
+      channel.expects(:send_data).with("GREAT Input\n")
+
+      mapping = lambda do |server_output|
+        case server_output
+        when /Some (\w+) output\n/
+          "#{$1.upcase} Input\n"
+        end
+      end
+
+      MappingInteractionHandler.new(mapping).on_stdout(channel, "Some great output\n", nil)
+    end
+
+
+    def test_matches_keys_in_ofer
+      interaction_handler = MappingInteractionHandler.new({
+        "Specific output\n" => "Specific Input\n",
+        /.*/ => "Default Input\n"
+      })
+
+      channel.expects(:send_data).with("Specific Input\n")
+      interaction_handler.on_stdout(channel, "Specific output\n", nil)
+    end
+
+    def test_supports_default_mapping
+      interaction_handler = MappingInteractionHandler.new({
+        "Specific output\n" => "Specific Input\n",
+        /.*/ => "Default Input\n"
+      })
+
+      channel.expects(:send_data).with("Specific Input\n")
+      interaction_handler.on_stdout(channel, "Specific output\n", nil)
+    end
+
+    def test_raises_for_unsupported_mapping_type
+      raised_error = assert_raises RuntimeError do
+        MappingInteractionHandler.new(Object.new)
+      end
+      assert_equal('Unsupported mapping type: Object - only Hash and Proc mappings are supported', raised_error.message)
+    end
+
+    def test_raises_for_unsupported_channel_type
+      handler = MappingInteractionHandler.new({"Some output\n" => "Whatever"})
+      raised_error = assert_raises RuntimeError do
+        handler.on_stdout(Object.new, "Some output\n", nil)
+      end
+      assert_match(/Unable to write response data to channel #<Object:.*> - does not support 'send_data' or 'write'/, raised_error.message)
     end
   end
 

--- a/test/unit/test_mapping_interaction_handler.rb
+++ b/test/unit/test_mapping_interaction_handler.rb
@@ -8,8 +8,9 @@ module SSHKit
     end
 
     def setup
+      super
       @output = stub(debug: anything)
-      SSHKit.config.stubs(:output).returns(@output)
+      SSHKit.config.output = @output
     end
 
     def test_calls_send_data_with_mapped_input_when_stdout_matches

--- a/test/unit/test_mapping_interaction_handler.rb
+++ b/test/unit/test_mapping_interaction_handler.rb
@@ -13,7 +13,7 @@ module SSHKit
     end
 
     def test_calls_send_data_with_mapped_input_when_stdout_matches
-      handler = MappingInteractionHandler.new('Server output' => 'some input')
+      handler = MappingInteractionHandler.new('Server output' => "some input\n")
 
       channel.expects(:send_data).with("some input\n")
 
@@ -21,7 +21,7 @@ module SSHKit
     end
 
     def test_calls_send_data_with_mapped_input_when_stderr_matches
-      handler = MappingInteractionHandler.new('Server output' => 'some input')
+      handler = MappingInteractionHandler.new('Server output' => "some input\n")
 
       channel.expects(:send_data).with("some input\n")
 

--- a/test/unit/test_mapping_interaction_handler.rb
+++ b/test/unit/test_mapping_interaction_handler.rb
@@ -7,12 +7,13 @@ module SSHKit
       @channel ||= mock
     end
 
-    def output
-      @output ||= stub(debug: anything)
+    def setup
+      @output = stub(debug: anything)
+      SSHKit.config.stubs(:output).returns(@output)
     end
 
     def test_calls_send_data_with_mapped_input_when_stdout_matches
-      handler = MappingInteractionHandler.new({'Server output' => 'some input'}, output)
+      handler = MappingInteractionHandler.new('Server output' => 'some input')
 
       channel.expects(:send_data).with("some input\n")
 
@@ -20,7 +21,7 @@ module SSHKit
     end
 
     def test_calls_send_data_with_mapped_input_when_stderr_matches
-      handler = MappingInteractionHandler.new({'Server output' => 'some input'}, output)
+      handler = MappingInteractionHandler.new('Server output' => 'some input')
 
       channel.expects(:send_data).with("some input\n")
 
@@ -28,9 +29,9 @@ module SSHKit
     end
 
     def test_raises_warning_if_server_output_is_not_matched
-      handler = MappingInteractionHandler.new({}, output)
+      handler = MappingInteractionHandler.new({})
 
-      output.expects(:warn).with('Unable to find interaction handler mapping for stdout: "Server output\n" so no response was sent')
+      @output.expects(:warn).with('Unable to find interaction handler mapping for stdout: "Server output\n" so no response was sent')
 
       handler.on_stdout(channel, "Server output\n", nil)
     end


### PR DESCRIPTION
This PR contains 4 improvements to the `:interaction_handler` option API from trying to use this with Capistrano in the real world:

1) Put the `MappingInteractionHandler` class in the `SSHKit` module
2) Support specifying an `interaction_handler` as a hash
```Ruby
# Before:
execute(:some_command, interaction_handler: SSHKit::MappingInteractionHandler.new("Some output\n" => "Input\n"))
# After:
execute(:some_command, interaction_handler: { "Some output\n" => "Input\n"})
```
3) No longer append a newline to the user input. This removes an inconsistency between the server side and user input side of the mapping:

```Ruby
# Before - newline needed on server output only because newline magically appended to input:
execute(:some_command, interaction_handler: { "Some output\n" => "Input"})
# After - no magic newline behaviour; all newlines should be specified:
execute(:some_command, interaction_handler: { "Some output\n" => "Input\n"})
```
4) Remove the`output` constructor parameter and attribute from `MappingInteractionHandler`. This was only added for unit testing purposes, but meant that it didn't work with [airbrussh](https://github.com/mattbrictson/airbrussh/commit/ec3122b101de53f2304723da842d5c8b6f70f4f3#diff-faf9277ec199ea9f2e313151176a085eR230). It also meant that `MappingInteractionHandler` would hold on to a reference to `SSHKit.config.output` which seems a bit dodgy to me in the case that `SSHKit.config.output` is updated after the `MappingInteractionHandler` is created.
