### PR TITLE
No colors for non tty outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ appear at the top.
 
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * Now only color the output if it is associated with a tty, or the `SSHKIT_COLOR` environment variable is set. (See [README](README.md#output-colors)) @robd
   * Removed broken support for assigning an `IO` to the `output` config option (See [#243](https://github.com/capistrano/sshkit/issues/243)). @robd
     * Use `SSHKit.config.output = SSHKit::Formatter::SimpleText.new($stdin)` instead
   * Added support for :interaction_handler option on commands. @robd

--- a/README.md
+++ b/README.md
@@ -359,16 +359,33 @@ However, if you prefer non colored text you can use the `:simpletext` formatter.
 there is also a `:dot` formatter which will simply output red or green dots based on the success or failure of commands.
 There is also a `:blackhole` formatter which does not output anything.
 
-By default, formatters log to `$stdout`, but they can be constructed with any `IO`:
+By default, formatters log to `$stdout`, but they can be constructed with any object which implements `<<`
+for example any `IO` subclass, `String`, `Logger` etc:
 
 ```ruby
-# Output to a StringIO:
-out = StringIO.new
-SSHKit.config.output = SSHKit::Formatter::Pretty.new(out)
-# Do something with out.string
+# Output to a String:
+output = String.new
+SSHKit.config.output = SSHKit::Formatter::Pretty.new(output)
+# Do something with output
 
 # Or output to a file:
 SSHKit.config.output = SSHKit::Formatter::SimpleText.new(File.open('log/deploy.log', 'wb'))
+```
+
+#### Output Colors
+
+By default, SSHKit will color the output using ANSI color escape sequences
+if the output you are using is associated with a terminal device (tty).
+This means that you should see colors if you are writing output to the terminal (the default),
+but you shouldn't see ANSI color escape sequences if you are writing to a file.
+
+Colors are supported for the `Pretty` and `Dot` formatters, but for historical reasons
+the `SimpleText` formatter never shows colors.
+
+If you want to force SSHKit to show colors, you can set the `SSHKIT_COLOR` environment variable:
+
+```ruby
+ENV['SSHKIT_COLOR'] = 'TRUE'
 ```
 
 #### Custom formatters

--- a/lib/sshkit/backends/printer.rb
+++ b/lib/sshkit/backends/printer.rb
@@ -1,14 +1,15 @@
 module SSHKit
   module Backend
 
+    # Printer is used to implement --dry-run in Capistrano
     class Printer < Abstract
 
       def execute_command(cmd)
         output << cmd
       end
+
       alias :upload! :execute
       alias :download! :execute
-      alias :test :execute
     end
   end
 end

--- a/lib/sshkit/color.rb
+++ b/lib/sshkit/color.rb
@@ -1,27 +1,19 @@
 require 'colorize'
 
-module Color
-  String.colors.each do |color|
-    instance_eval <<-RUBY, __FILE__, __LINE__
-      def #{color}(string = '')
-        string = yield if block_given?
-        colorize? ? string.colorize(:color => :#{color}) : string
-      end
-    RUBY
-  end
+module SSHKit
+  class Color
 
-  String.modes.each do |mode|
-    instance_eval <<-RUBY, __FILE__, __LINE__
-      def #{mode}(string = '')
-        string = yield if block_given?
-        colorize? ? string.colorize(:mode => :#{mode}) : string
-      end
-    RUBY
-  end
+    def initialize(io=$stdout, env=ENV)
+      @io, @env = io, env
+    end
 
-  class << self
+    def colorize(obj, color, mode=nil)
+      string = obj.to_s
+      colorize? ? string.colorize(color: color, mode: mode) : string
+    end
+
     def colorize?
-      ENV['SSHKIT_COLOR'] || $stdout.tty?
+      @env['SSHKIT_COLOR'] || @io.tty?
     end
   end
 end

--- a/lib/sshkit/color.rb
+++ b/lib/sshkit/color.rb
@@ -2,8 +2,7 @@ require 'colorize'
 
 module SSHKit
   class Color
-
-    def initialize(io=$stdout, env=ENV)
+    def initialize(io, env=ENV)
       @io, @env = io, env
     end
 

--- a/lib/sshkit/color.rb
+++ b/lib/sshkit/color.rb
@@ -2,8 +2,8 @@ require 'colorize'
 
 module SSHKit
   class Color
-    def initialize(io, env=ENV)
-      @io, @env = io, env
+    def initialize(output, env=ENV)
+      @output, @env = output, env
     end
 
     def colorize(obj, color, mode=nil)
@@ -12,7 +12,7 @@ module SSHKit
     end
 
     def colorize?
-      @env['SSHKIT_COLOR'] || @io.tty?
+      @env['SSHKIT_COLOR'] || (@output.respond_to?(:tty?) && @output.tty?)
     end
   end
 end

--- a/lib/sshkit/formatters/abstract.rb
+++ b/lib/sshkit/formatters/abstract.rb
@@ -49,6 +49,10 @@ module SSHKit
         ("\t" + line).chomp
       end
 
+      def colorize(obj, color, mode=nil)
+        SSHKit::Color.new.colorize(obj, color, mode)
+      end
+
       private
 
       def write_at_log_level(level, messages)

--- a/lib/sshkit/formatters/abstract.rb
+++ b/lib/sshkit/formatters/abstract.rb
@@ -11,9 +11,9 @@ module SSHKit
       def_delegators :@original_output, :read, :rewind
       def_delegators :@color, :colorize
 
-      def initialize(oio)
-        @original_output = oio
-        @color = SSHKit::Color.new(oio)
+      def initialize(output)
+        @original_output = output
+        @color = SSHKit::Color.new(output)
       end
 
       def log(messages)

--- a/lib/sshkit/formatters/abstract.rb
+++ b/lib/sshkit/formatters/abstract.rb
@@ -9,9 +9,11 @@ module SSHKit
       extend Forwardable
       attr_reader :original_output
       def_delegators :@original_output, :read, :rewind
+      def_delegators :@color, :colorize
 
       def initialize(oio)
         @original_output = oio
+        @color = SSHKit::Color.new(oio)
       end
 
       def log(messages)
@@ -47,10 +49,6 @@ module SSHKit
 
       def format_std_stream_line(line)
         ("\t" + line).chomp
-      end
-
-      def colorize(obj, color, mode=nil)
-        SSHKit::Color.new.colorize(obj, color, mode)
       end
 
       private

--- a/lib/sshkit/formatters/dot.rb
+++ b/lib/sshkit/formatters/dot.rb
@@ -7,16 +7,10 @@ module SSHKit
       def write(obj)
         return unless obj.is_a? SSHKit::Command
         if obj.finished?
-          original_output << (obj.failure? ? c.red('.') : c.green('.'))
+          original_output << colorize('.', obj.failure? ? :red : :green)
         end
       end
       alias :<< :write
-
-      private
-
-      def c
-        @c ||= Color
-      end
 
     end
 

--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -19,47 +19,43 @@ module SSHKit
 
       def write_command(command)
         unless command.started?
-          host_prefix = command.host.user ? "as #{c.blue(command.host.user)}@" : 'on '
-          write_command_message("Running #{c.yellow(c.bold(String(command)))} #{host_prefix}#{c.blue(command.host.to_s)}", command)
+          host_prefix = command.host.user ? "as #{colorize(command.host.user, :blue)}@" : 'on '
+          write_command_message("Running #{colorize(command, :yellow, :bold)} #{host_prefix}#{colorize(command.host, :blue)}", command)
           if SSHKit.config.output_verbosity == Logger::DEBUG
-            write_command_message("Command: #{c.blue(command.to_command)}", command, Logger::DEBUG)
+            write_command_message("Command: #{colorize(command.to_command, :blue)}", command, Logger::DEBUG)
           end
         end
 
         if SSHKit.config.output_verbosity == Logger::DEBUG
           command.clear_stdout_lines.each do |line|
-            write_command_message(c.green(format_std_stream_line(line)), command, Logger::DEBUG)
+            write_command_message(colorize(format_std_stream_line(line), :green), command, Logger::DEBUG)
           end
 
           command.clear_stderr_lines.each do |line|
-            write_command_message(c.red(format_std_stream_line(line)), command, Logger::DEBUG)
+            write_command_message(colorize(format_std_stream_line(line), :red), command, Logger::DEBUG)
           end
         end
 
         if command.finished?
-          successful_or_failed = c.bold { command.failure? ? c.red('failed') : c.green('successful') }
+          successful_or_failed =  command.failure? ? colorize('failed', :red, :bold) : colorize('successful', :green, :bold)
           write_command_message("Finished in #{sprintf('%5.3f seconds', command.runtime)} with exit status #{command.exit_status} (#{successful_or_failed}).", command)
         end
       end
 
       def write_command_message(message, command, verbosity_override=nil)
-        original_output << "%6s [%s] %s\n" % [level(verbosity_override || command.verbosity), c.green(command.uuid), message]
+        original_output << "%6s [%s] %s\n" % [level(verbosity_override || command.verbosity), colorize(command.uuid, :green), message]
       end
 
       def write_log_message(log_message)
         original_output << "%6s %s\n" % [level(log_message.verbosity), log_message.to_s]
       end
 
-      def c
-        @c ||= Color
-      end
-
       def level(verbosity)
-        c.send(level_formatting(verbosity), level_names(verbosity))
+        colorize(level_names(verbosity), level_formatting(verbosity))
       end
 
       def level_formatting(level_num)
-        %w{ black blue yellow red red }[level_num]
+        [:black, :blue, :yellow, :red, :red][level_num]
       end
 
       def level_names(level_num)

--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -5,12 +5,12 @@ module SSHKit
     class Pretty < Abstract
 
       def write(obj)
-        return if obj.verbosity < SSHKit.config.output_verbosity
+        return if obj.respond_to?(:verbosity) && obj.verbosity < SSHKit.config.output_verbosity
         case obj
         when SSHKit::Command    then write_command(obj)
         when SSHKit::LogMessage then write_log_message(obj)
         else
-          original_output << c.black(c.on_yellow("Output formatter doesn't know how to handle #{obj.class}\n"))
+          raise "Output formatter only supports formatting SSHKit::Command and SSHKit::LogMessage, called with #{obj.class}: #{obj.inspect}"
         end
       end
       alias :<< :write

--- a/lib/sshkit/formatters/simple_text.rb
+++ b/lib/sshkit/formatters/simple_text.rb
@@ -6,12 +6,12 @@ module SSHKit
     class SimpleText < Abstract
 
       def write(obj)
-        return if obj.verbosity < SSHKit.config.output_verbosity
+        return if obj.respond_to?(:verbosity) && obj.verbosity < SSHKit.config.output_verbosity
         case obj
         when SSHKit::Command    then write_command(obj)
         when SSHKit::LogMessage then write_log_message(obj)
         else
-          original_output << "Output formatter doesn't know how to handle #{obj.class}\n"
+          raise "Output formatter only supports formatting SSHKit::Command and SSHKit::LogMessage, called with #{obj.class}: #{obj.inspect}"
         end
       end
       alias :<< :write

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -6,6 +6,7 @@ module SSHKit
     class TestLocal < MiniTest::Unit::TestCase
 
       def setup
+        super
         SSHKit.config.output = SSHKit::Formatter::BlackHole.new($stdout)
       end
 

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -10,9 +10,9 @@ module SSHKit
 
       def setup
         super
-        @out = StringIO.new
+        @output = String.new
         SSHKit.config.output_verbosity = :debug
-        SSHKit.config.output = SSHKit::Formatter::SimpleText.new(@out)
+        SSHKit.config.output = SSHKit::Formatter::SimpleText.new(@output)
       end
 
       def a_host
@@ -32,7 +32,7 @@ module SSHKit
           end
         end.run
 
-        command_lines = @out.string.lines.select { |line| line.start_with?('Command:') }
+        command_lines = @output.lines.select { |line| line.start_with?('Command:') }
         assert_equal <<-EOEXPECTED.unindent, command_lines.join
           Command: /usr/bin/env date
           Command: /usr/bin/env ls -l

--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -6,6 +6,7 @@ module SSHKit
     class TestConnectionPool < UnitTest
 
       def setup
+        super
         pool.flush_connections
       end
 

--- a/test/unit/backends/test_printer.rb
+++ b/test/unit/backends/test_printer.rb
@@ -1,0 +1,73 @@
+require 'helper'
+
+module SSHKit
+  module Backend
+    class TestPrinter < UnitTest
+
+      def setup
+        super
+        SSHKit.config.output = SSHKit::Formatter::Pretty.new(output)
+        SSHKit.config.output_verbosity = Logger::DEBUG
+        Command.any_instance.stubs(:uuid).returns('aaaaaa')
+      end
+
+      def output
+        @output ||= StringIO.new
+      end
+
+      def printer
+        @printer ||= Printer.new(Host.new('example.com'))
+      end
+
+      def test_execute
+        printer.execute 'uname -a'
+        assert_output_lines(
+          '  INFO [aaaaaa] Running /usr/bin/env uname -a on example.com',
+          ' DEBUG [aaaaaa] Command: uname -a'
+        )
+      end
+
+      def test_test_method
+        printer.test '[ -d /some/file ]'
+
+        assert_output_lines(
+          ' DEBUG [aaaaaa] Running /usr/bin/env [ -d /some/file ] on example.com',
+          ' DEBUG [aaaaaa] Command: [ -d /some/file ]'
+        )
+      end
+
+      def test_capture
+        result = printer.capture 'ls -l'
+
+        assert_equal '', result
+
+        assert_output_lines(
+          ' DEBUG [aaaaaa] Running /usr/bin/env ls -l on example.com',
+          ' DEBUG [aaaaaa] Command: ls -l'
+        )
+      end
+
+      def test_upload
+        printer.upload! '/some/file', '/remote'
+        assert_output_lines(
+          '  INFO [aaaaaa] Running /usr/bin/env /some/file /remote on example.com',
+          ' DEBUG [aaaaaa] Command: /usr/bin/env /some/file /remote'
+        )
+      end
+
+      def test_download
+        printer.download! 'remote/file', '/local/path'
+        assert_output_lines(
+          '  INFO [aaaaaa] Running /usr/bin/env remote/file /local/path on example.com',
+          ' DEBUG [aaaaaa] Command: /usr/bin/env remote/file /local/path'
+        )
+      end
+
+      private
+
+      def assert_output_lines(*expected_lines)
+        assert_equal(expected_lines, output.string.split("\n"))
+      end
+    end
+  end
+end

--- a/test/unit/backends/test_printer.rb
+++ b/test/unit/backends/test_printer.rb
@@ -12,7 +12,7 @@ module SSHKit
       end
 
       def output
-        @output ||= StringIO.new
+        @output ||= String.new
       end
 
       def printer
@@ -66,7 +66,7 @@ module SSHKit
       private
 
       def assert_output_lines(*expected_lines)
-        assert_equal(expected_lines, output.string.split("\n"))
+        assert_equal(expected_lines, output.split("\n"))
       end
     end
   end

--- a/test/unit/formatters/test_dot.rb
+++ b/test/unit/formatters/test_dot.rb
@@ -30,6 +30,7 @@ module SSHKit
     end
 
     def test_command_success
+      output.stubs(:tty?).returns(true)
       command = SSHKit::Command.new(:ls)
       command.exit_status = 0
       dot << command
@@ -37,6 +38,7 @@ module SSHKit
     end
 
     def test_command_failure
+      output.stubs(:tty?).returns(true)
       command = SSHKit::Command.new(:ls, {raise_on_non_zero_exit: false})
       command.exit_status = 1
       dot << command

--- a/test/unit/formatters/test_dot.rb
+++ b/test/unit/formatters/test_dot.rb
@@ -17,12 +17,6 @@ module SSHKit
       @_dot ||= SSHKit::Formatter::Dot.new(output)
     end
 
-    def teardown
-      remove_instance_variable :@_dot
-      remove_instance_variable :@_output
-      SSHKit.reset_configuration!
-    end
-
     def test_logging_fatal
       dot << SSHKit::LogMessage.new(Logger::FATAL, "Test")
       assert_equal "", output.strip

--- a/test/unit/formatters/test_dot.rb
+++ b/test/unit/formatters/test_dot.rb
@@ -9,7 +9,7 @@ module SSHKit
     end
 
     def output
-      @output ||= StringIO.new
+      @output ||= String.new
     end
 
     def dot
@@ -53,7 +53,7 @@ module SSHKit
     private
 
     def assert_log_output(expected_output)
-      assert_equal expected_output, output.string
+      assert_equal expected_output, output
     end
   end
 end

--- a/test/unit/formatters/test_dot.rb
+++ b/test/unit/formatters/test_dot.rb
@@ -19,27 +19,38 @@ module SSHKit
     %w(fatal error warn info debug).each do |level|
       define_method("test_#{level}_output") do
         dot.send(level, 'Test')
-        assert_output('')
+        assert_log_output('')
       end
+    end
+
+    def test_unfinished_command
+      command = SSHKit::Command.new(:ls)
+      dot << command
+      assert_log_output('')
     end
 
     def test_command_success
       command = SSHKit::Command.new(:ls)
       command.exit_status = 0
       dot << command
-      assert_output("\e[0;32;49m.\e[0m")
+      assert_log_output("\e[0;32;49m.\e[0m")
     end
 
     def test_command_failure
       command = SSHKit::Command.new(:ls, {raise_on_non_zero_exit: false})
       command.exit_status = 1
       dot << command
-      assert_output("\e[0;31;49m.\e[0m")
+      assert_log_output("\e[0;31;49m.\e[0m")
+    end
+
+    def test_unsupported_class
+      dot << Pathname.new('/tmp')
+      assert_log_output('')
     end
 
     private
 
-    def assert_output(expected_output)
+    def assert_log_output(expected_output)
       assert_equal expected_output, output.string
     end
   end

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -38,7 +38,7 @@ module SSHKit
     end
 
     def test_command_lifecycle_logging
-      command = SSHKit::Command.new(:a_cmd, 'some args', host: Host.new('localhost'))
+      command = SSHKit::Command.new(:a_cmd, 'some args', host: Host.new('user@localhost'))
       command.stubs(:uuid).returns('aaaaaa')
       command.stubs(:runtime).returns(1)
       pretty << command
@@ -52,7 +52,7 @@ module SSHKit
       pretty << command
 
       expected_log_lines = [
-        "\e[0;34;49mINFO\e[0m [\e[0;32;49maaaaaa\e[0m] Running \e[1;33;49m/usr/bin/env a_cmd some args\e[0m on \e[0;34;49mlocalhost\e[0m",
+        "\e[0;34;49mINFO\e[0m [\e[0;32;49maaaaaa\e[0m] Running \e[1;33;49m/usr/bin/env a_cmd some args\e[0m as \e[0;34;49muser\e[0m@\e[0;34;49mlocalhost\e[0m",
         "\e[0;30;49mDEBUG\e[0m [\e[0;32;49maaaaaa\e[0m] Command: \e[0;34;49m/usr/bin/env a_cmd some args\e[0m",
         "\e[0;30;49mDEBUG\e[0m [\e[0;32;49maaaaaa\e[0m] \e[0;32;49m\tstdout message\e[0m",
         "\e[0;30;49mDEBUG\e[0m [\e[0;32;49maaaaaa\e[0m] \e[0;31;49m\tstderr message\e[0m",

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -17,12 +17,6 @@ module SSHKit
       @_pretty ||= SSHKit::Formatter::Pretty.new(output)
     end
 
-    def teardown
-      remove_instance_variable :@_pretty
-      remove_instance_variable :@_output
-      SSHKit.reset_configuration!
-    end
-
     def test_logging_fatal
       assert_equal "\e[0;31;49mFATAL\e[0m Test\n", pretty.fatal('Test')
     end

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -1,5 +1,4 @@
 require 'helper'
-require 'sshkit'
 
 module SSHKit
   class TestPretty < UnitTest
@@ -10,34 +9,43 @@ module SSHKit
     end
 
     def output
-      @_output ||= String.new
+      @output ||= StringIO.new
     end
 
     def pretty
-      @_pretty ||= SSHKit::Formatter::Pretty.new(output)
+      @pretty ||= SSHKit::Formatter::Pretty.new(output)
     end
 
-    def test_logging_fatal
-      assert_equal "\e[0;31;49mFATAL\e[0m Test\n", pretty.fatal('Test')
-    end
-
-    def test_logging_error
-      assert_equal "\e[0;31;49mERROR\e[0m Test\n", pretty.error('Test')
-    end
-
-    def test_logging_warn
-      assert_equal "\e[0;33;49mWARN\e[0m Test\n", pretty.warn('Test')
-    end
-
-    def test_logging_info
-      assert_equal "\e[0;34;49mINFO\e[0m Test\n", pretty.info('Test')
-    end
-
-    def test_logging_debug
-      assert_equal "\e[0;30;49mDEBUG\e[0m Test\n", pretty.debug('Test')
+    {
+      log:   "\e[0;34;49mINFO\e[0m Test\n",
+      fatal: "\e[0;31;49mFATAL\e[0m Test\n",
+      error: "\e[0;31;49mERROR\e[0m Test\n",
+      warn:  "\e[0;33;49mWARN\e[0m Test\n",
+      info:  "\e[0;34;49mINFO\e[0m Test\n",
+      debug: "\e[0;30;49mDEBUG\e[0m Test\n"
+    }.each do |level, expected_output|
+      define_method("test_#{level}_output") do
+        pretty.send(level, 'Test')
+        assert_equal expected_output, output.string
+      end
     end
 
     def test_command_lifecycle_logging
+      execute_command_lifecycle
+
+      expected_log_lines = [
+        "\e[0;34;49mINFO\e[0m [\e[0;32;49maaaaaa\e[0m] Running \e[1;33;49m/usr/bin/env a_cmd some args\e[0m as \e[0;34;49muser\e[0m@\e[0;34;49mlocalhost\e[0m",
+        "\e[0;30;49mDEBUG\e[0m [\e[0;32;49maaaaaa\e[0m] Command: \e[0;34;49m/usr/bin/env a_cmd some args\e[0m",
+        "\e[0;30;49mDEBUG\e[0m [\e[0;32;49maaaaaa\e[0m] \e[0;32;49m\tstdout message\e[0m",
+        "\e[0;30;49mDEBUG\e[0m [\e[0;32;49maaaaaa\e[0m] \e[0;31;49m\tstderr message\e[0m",
+        "\e[0;34;49mINFO\e[0m [\e[0;32;49maaaaaa\e[0m] Finished in 1.000 seconds with exit status 0 (\e[1;32;49msuccessful\e[0m)."
+      ]
+      assert_equal expected_log_lines, output.string.split("\n")
+    end
+
+    private
+
+    def execute_command_lifecycle
       command = SSHKit::Command.new(:a_cmd, 'some args', host: Host.new('user@localhost'))
       command.stubs(:uuid).returns('aaaaaa')
       command.stubs(:runtime).returns(1)
@@ -50,15 +58,6 @@ module SSHKit
       pretty << command
       command.exit_status = 0
       pretty << command
-
-      expected_log_lines = [
-        "\e[0;34;49mINFO\e[0m [\e[0;32;49maaaaaa\e[0m] Running \e[1;33;49m/usr/bin/env a_cmd some args\e[0m as \e[0;34;49muser\e[0m@\e[0;34;49mlocalhost\e[0m",
-        "\e[0;30;49mDEBUG\e[0m [\e[0;32;49maaaaaa\e[0m] Command: \e[0;34;49m/usr/bin/env a_cmd some args\e[0m",
-        "\e[0;30;49mDEBUG\e[0m [\e[0;32;49maaaaaa\e[0m] \e[0;32;49m\tstdout message\e[0m",
-        "\e[0;30;49mDEBUG\e[0m [\e[0;32;49maaaaaa\e[0m] \e[0;31;49m\tstderr message\e[0m",
-        "\e[0;34;49mINFO\e[0m [\e[0;32;49maaaaaa\e[0m] Finished in 1.000 seconds with exit status 0 (\e[1;32;49msuccessful\e[0m)."
-      ]
-      assert_equal expected_log_lines, output.split("\n")
     end
 
   end

--- a/test/unit/formatters/test_simple_text.rb
+++ b/test/unit/formatters/test_simple_text.rb
@@ -38,7 +38,7 @@ module SSHKit
     end
 
     def test_command_lifecycle_logging
-      command = SSHKit::Command.new(:a_cmd, 'some args', host: Host.new('localhost'))
+      command = SSHKit::Command.new(:a_cmd, 'some args', host: Host.new('user@localhost'))
       command.stubs(:uuid).returns('aaaaaa')
       command.stubs(:runtime).returns(1)
 
@@ -53,7 +53,7 @@ module SSHKit
       simple << command
 
       expected_log_lines = [
-        'Running /usr/bin/env a_cmd some args on localhost',
+        'Running /usr/bin/env a_cmd some args as user@localhost',
         'Command: /usr/bin/env a_cmd some args',
         "\tstdout message",
         "\tstderr message",

--- a/test/unit/formatters/test_simple_text.rb
+++ b/test/unit/formatters/test_simple_text.rb
@@ -17,12 +17,6 @@ module SSHKit
       @_simple ||= SSHKit::Formatter::SimpleText.new(output)
     end
 
-    def teardown
-      remove_instance_variable :@_simple
-      remove_instance_variable :@_output
-      SSHKit.reset_configuration!
-    end
-
     def test_logging_fatal
       assert_equal "Test\n", simple.fatal('Test')
     end

--- a/test/unit/formatters/test_simple_text.rb
+++ b/test/unit/formatters/test_simple_text.rb
@@ -1,5 +1,4 @@
 require 'helper'
-require 'sshkit'
 
 module SSHKit
   class TestSimpleText < UnitTest
@@ -10,31 +9,18 @@ module SSHKit
     end
 
     def output
-      @_output ||= String.new
+      @output ||= StringIO.new
     end
 
     def simple
-      @_simple ||= SSHKit::Formatter::SimpleText.new(output)
+      @simple ||= SSHKit::Formatter::SimpleText.new(output)
     end
 
-    def test_logging_fatal
-      assert_equal "Test\n", simple.fatal('Test')
-    end
-
-    def test_logging_error
-      assert_equal "Test\n", simple.error('Test')
-    end
-
-    def test_logging_warn
-      assert_equal "Test\n", simple.warn('Test')
-    end
-
-    def test_logging_info
-      assert_equal "Test\n", simple.info('Test')
-    end
-
-    def test_logging_debug
-      assert_equal "Test\n", simple.debug('Test')
+    %w(fatal error warn info debug).each do |level|
+      define_method("test_#{level}_output") do
+        simple.send(level, 'Test')
+        assert_equal "Test\n", output.string
+      end
     end
 
     def test_command_lifecycle_logging
@@ -59,7 +45,7 @@ module SSHKit
         "\tstderr message",
         'Finished in 1.000 seconds with exit status 0 (successful).'
       ]
-      assert_equal expected_log_lines, output.split("\n")
+      assert_equal expected_log_lines, output.string.split("\n")
     end
 
   end

--- a/test/unit/formatters/test_simple_text.rb
+++ b/test/unit/formatters/test_simple_text.rb
@@ -48,5 +48,27 @@ module SSHKit
       assert_equal expected_log_lines, output.string.split("\n")
     end
 
+    def test_unsupported_class
+      raised_error = assert_raises RuntimeError do
+        simple << Pathname.new('/tmp')
+      end
+      assert_equal('Output formatter only supports formatting SSHKit::Command and SSHKit::LogMessage, called with Pathname: #<Pathname:/tmp>', raised_error.message)
+    end
+
+    def test_does_not_log_when_verbosity_is_too_low
+      SSHKit.config.output_verbosity = Logger::WARN
+      simple.info('Some info')
+      assert_log_output('')
+
+      SSHKit.config.output_verbosity = Logger::INFO
+      simple.info('Some other info')
+      assert_log_output("Some other info\n")
+    end
+
+    private
+
+    def assert_log_output(expected_output)
+      assert_equal expected_output, output.string
+    end
   end
 end

--- a/test/unit/formatters/test_simple_text.rb
+++ b/test/unit/formatters/test_simple_text.rb
@@ -9,7 +9,7 @@ module SSHKit
     end
 
     def output
-      @output ||= StringIO.new
+      @output ||= String.new
     end
 
     def simple
@@ -19,7 +19,7 @@ module SSHKit
     %w(fatal error warn info debug).each do |level|
       define_method("test_#{level}_output") do
         simple.send(level, 'Test')
-        assert_equal "Test\n", output.string
+        assert_equal "Test\n", output
       end
     end
 
@@ -45,7 +45,7 @@ module SSHKit
         "\tstderr message",
         'Finished in 1.000 seconds with exit status 0 (successful).'
       ]
-      assert_equal expected_log_lines, output.string.split("\n")
+      assert_equal expected_log_lines, output.split("\n")
     end
 
     def test_unsupported_class
@@ -68,7 +68,7 @@ module SSHKit
     private
 
     def assert_log_output(expected_output)
-      assert_equal expected_output, output.string
+      assert_equal expected_output, output
     end
   end
 end

--- a/test/unit/test_color.rb
+++ b/test/unit/test_color.rb
@@ -18,5 +18,13 @@ module SSHKit
       color = SSHKit::Color.new(stub(tty?: false), {})
       assert_equal 'hi', color.colorize('hi', :red)
     end
+
+    # The output parameter may not define the tty method eg if it is a Logger.
+    # In this case we assume showing colors would not be supported
+    # https://github.com/capistrano/sshkit/pull/246#issuecomment-100358122
+    def test_does_not_colorize_when_tty_method_not_defined_and_SSHKIT_COLOR_not_present
+      color = SSHKit::Color.new(stub(), {})
+      assert_equal 'hi', color.colorize('hi', :red)
+    end
   end
 end

--- a/test/unit/test_color.rb
+++ b/test/unit/test_color.rb
@@ -4,13 +4,19 @@ require 'sshkit'
 module SSHKit
   class TestColor < UnitTest
 
-    def test_responds_to_colorize?
-      assert Color.respond_to?(:colorize?)
+    def test_colorize_when_tty_available
+      color = SSHKit::Color.new(stub(tty?: true), {})
+      assert_equal "\e[1;32;49mhi\e[0m", color.colorize('hi', :green, :bold)
     end
 
-    def test_not_fails_on_bold_mode
-      Color.stubs(:colorize?).returns true
-      assert_equal Color.bold("test"), 'test'.bold
+    def test_colorize_when_SSHKIT_COLOR_present
+      color = SSHKit::Color.new(stub(tty?: false), {'SSHKIT_COLOR' => 'a'})
+      assert_equal "\e[0;31;49mhi\e[0m", color.colorize('hi', :red)
+    end
+
+    def test_does_not_colorize_when_no_tty_and_SSHKIT_COLOR_not_present
+      color = SSHKit::Color.new(stub(tty?: false), {})
+      assert_equal 'hi', color.colorize('hi', :red)
     end
   end
 end

--- a/test/unit/test_coordinator.rb
+++ b/test/unit/test_coordinator.rb
@@ -7,9 +7,9 @@ module SSHKit
 
     def setup
       super
-      @out = StringIO.new
+      @output = String.new
       SSHKit.config.output_verbosity = :debug
-      SSHKit.config.output = SSHKit::Formatter::SimpleText.new(@out)
+      SSHKit.config.output = SSHKit::Formatter::SimpleText.new(@output)
       SSHKit.config.backend = SSHKit::Backend::Printer
     end
 
@@ -97,7 +97,7 @@ module SSHKit
     end
 
     def actual_output_commands
-      @out.string.lines.select { |line| line.start_with?('Command:') }
+      @output.lines.select { |line| line.start_with?('Command:') }
     end
 
   end


### PR DESCRIPTION
As discussed in #245, this PR reworks color support so that we don't ouput ANSI color escape sequences for output IOs which aren't associated with a tty.

The main rework is to convert the `Color` module into a class which can be instantiated with the output IO, rather than just being hard coded to the `$stdout.tty?`

As part of this change, I was trying to add a test for the colors [in this message](https://github.com/capistrano/sshkit/blob/c9de10d38f5ddb81e8bdbacf58ac4e5094277d03/lib/sshkit/formatters/pretty.rb#L13) in the pretty formatter:

```ruby
c.black(c.on_yellow("Output formatter doesn't know how to handle #{obj.class}\n"))
```

Calling write with an unexpected object type didn't call the above line, but instead raised an exception - (`undefined method 'verbosity' for #<Object:0x007f8b73695450>`) [here](https://github.com/capistrano/sshkit/blob/c9de10d38f5ddb81e8bdbacf58ac4e5094277d03/lib/sshkit/formatters/pretty.rb#L8), which meant that the line above was basically unreachable.

I made this line reachable by checking for the presence of the `verbosity` method and I saw this error instead `undefined method 'on_yellow' for Color:Module`. 

I looked through the historical issues on SSHKit and Capistrano about the verbosity and on_yellow errors. There are several verbosity messgage issues which were was associated with the `--dry-run` option and I found [this @leehambley comment](https://github.com/capistrano/sshkit/issues/39#issuecomment-27414697):

> I can confirm the log formatters expect objects on `Command` and `LogMessage` (?) classes. Any thing contrary is incorrect

Therefore, it seems to me that, in practice, we are never calling a formatter with a non `Command` / `LogMessage` object. Therefore, I've added tests to raise this as a more helpful error, and removed the coloring from the message.

Hopefully everything else is obvious. 