### PR TITLE
Add strip option to capture, reinstate stripping by default in the capture methods

### DIFF
--- a/BREAKING_API_WISHLIST.md
+++ b/BREAKING_API_WISHLIST.md
@@ -1,0 +1,6 @@
+# Breaking API Wishlist
+
+SSHKit respects semantic versioning. This file is a place to record breaking API improvements
+which could be considered at the next major release.
+
+* Consider no longer stripping by default on `capture` [#249](https://github.com/capistrano/sshkit/pull/249)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,13 @@ appear at the top.
   * Removed partially supported `TRACE` log level.
     [2aa7890](https://github.com/capistrano/sshkit/commit/2aa78905f0c521ad9f697e7a4ed04ba438d5ee78)
     @robd
-  * No longer strip whitespace or newlines in `capture` method on Netssh backend.
-    [PR #239](https://github.com/capistrano/sshkit/pull/239)
+  * Add support for the `:strip` option to the `capture` method and strip by default on the `Local` backend.
+    [PR #239](https://github.com/capistrano/sshkit/pull/239),
+    [PR #249](https://github.com/capistrano/sshkit/pull/249)
     @robd
-    * This is to make the `Local` and `Netssh` backends consistent
-      (they diverged at [7d15a9a](https://github.com/capistrano/sshkit/commit/7d15a9aebfcc43807c8151bf6f3a4bc038ce6218))
-    * If you need the old behaviour back, call `.strip` (or `.chomp`) on the captured string
-      i.e. `capture(:my_command).strip`
+    * The `Local` backend now strips by default to be consistent with the `Netssh` one.
+    * This reverses change [7d15a9a](https://github.com/capistrano/sshkit/commit/7d15a9aebfcc43807c8151bf6f3a4bc038ce6218) to the `Local` capture API to remove stripping by default.
+    * If you require the raw, unstripped output, pass the `strip: false` option: `capture(:ls, strip: false)`
   * Simplified backend hierarchy.
     [PR #235](https://github.com/capistrano/sshkit/pull/235),
     [PR #237](https://github.com/capistrano/sshkit/pull/237)

--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -35,8 +35,9 @@ module SSHKit
       end
 
       def capture(*args)
-        options = { verbosity: Logger::DEBUG }.merge(args.extract_options!)
-        create_command_and_execute(args, options).full_stdout
+        options = { verbosity: Logger::DEBUG, strip: true }.merge(args.extract_options!)
+        result = create_command_and_execute(args, options).full_stdout
+        options[:strip] ? result.strip : result
       end
 
       def background(*args)

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -13,7 +13,7 @@ module SSHKit
       def test_capture
         captured_command_result = ''
         Local.new do
-          captured_command_result = capture(:echo, 'foo')
+          captured_command_result = capture(:echo, 'foo', strip: false)
         end.run
         assert_equal "foo\n", captured_command_result
       end
@@ -46,7 +46,7 @@ module SSHKit
             "Captured SOME DATA\n" => nil
           })
         end.run
-        assert_equal("Enter Data\nCaptured SOME DATA\n", captured_command_result)
+        assert_equal("Enter Data\nCaptured SOME DATA", captured_command_result)
       end
     end
   end

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -48,7 +48,7 @@ module SSHKit
           captured_command_result = capture(:uname)
         end.run
 
-        assert_includes %W(Linux\n Darwin\n), captured_command_result
+        assert_includes %W(Linux Darwin), captured_command_result
       end
 
       def test_ssh_option_merge
@@ -85,7 +85,7 @@ module SSHKit
         end
         Netssh.new(a_host) do
           upload!(file_name, file_name)
-          actual_file_contents = capture(:cat, file_name)
+          actual_file_contents = capture(:cat, file_name, strip: false)
         end.run
         assert_equal "Some Content\nWith a newline and trailing spaces    \n ", actual_file_contents
       end
@@ -124,7 +124,7 @@ module SSHKit
             "Captured SOME DATA\n" => nil
           })
         end.run
-        assert_equal("Enter Data\nCaptured SOME DATA\n", captured_command_result)
+        assert_equal("Enter Data\nCaptured SOME DATA", captured_command_result)
       end
     end
 

--- a/test/unit/backends/test_abstract.rb
+++ b/test/unit/backends/test_abstract.rb
@@ -51,17 +51,30 @@ module SSHKit
         assert_equal false, backend.executed_command.options[:raise_on_non_zero_exit], 'raise_on_non_zero_exit option'
       end
 
-      def test_capture_creates_and_executes_command_and_returns_output
+      def test_capture_creates_and_executes_command_and_returns_stripped_output
         output = nil
         backend = ExampleBackend.new do
           output = capture :cat, '/a/file'
         end
-        backend.full_stdout = 'Some stdout'
+        backend.full_stdout = "Some stdout\n     "
 
         backend.run
 
         assert_equal '/usr/bin/env cat /a/file', backend.executed_command.to_command
         assert_equal 'Some stdout', output
+      end
+
+      def test_capture_supports_disabling_strip
+        output = nil
+        backend = ExampleBackend.new do
+          output = capture :cat, '/a/file', :strip => false
+        end
+        backend.full_stdout = "Some stdout\n     "
+
+        backend.run
+
+        assert_equal '/usr/bin/env cat /a/file', backend.executed_command.to_command
+        assert_equal "Some stdout\n     ", output
       end
 
       def test_calling_abstract_with_undefined_execute_command_raises_exception


### PR DESCRIPTION
I am nervous about the decision we made over in #239, to no longer strip the output of `capture`. Having seen some of the issues that are raised, I think there might be quite a lot of fallout from this. I'm particularly worried that this may not fail in an easy-to-understand way, and that we may waste a lot of everyones time dealing with them. I also think that in many cases, eg the [one liners in Capistrano](https://github.com/mattbrictson/capistrano/commit/ad8682de34ac78ba69da1569fe0fcdfa3014dc6d), stripping is a reasonable default.

I do still think that we should make the API consistent between the `Local` and `NetSSH` backends. Therefore, I'd like to propose that we make stripping whitespace the default, but add an option to the capture method to turn off stripping.

@townsen Would you be OK with adding the `strip: false` option in the Local cases where you need full whitespace?

This PR also adds some docs for the basic SSHKit usage, which I believe were sort of missing from the README.
