### PR TITLE
Quote environment variable values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ appear at the top.
 
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * Quote environment variable values.
+    [PR #250](https://github.com/capistrano/sshkit/pull/250)
+    @Sinjo - Chris Sinjakli
   * Simplified formatter hierarchy.
     [PR #248](https://github.com/capistrano/sshkit/pull/248)
     @robd

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -143,11 +143,9 @@ module SSHKit
 
     def environment_string
       environment_hash.collect do |key,value|
-        if key.is_a? Symbol
-          "#{key.to_s.upcase}=\"#{value.to_s.gsub(/"/, '\"')}\""
-        else
-          "#{key.to_s}=\"#{value.to_s.gsub(/"/, '\"')}\""
-        end
+        key_string = key.is_a?(Symbol) ? key.to_s.upcase : key.to_s
+        escaped_value = value.to_s.gsub(/"/, '\"')
+        %{#{key_string}="#{escaped_value}"}
       end.join(' ')
     end
 

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -144,9 +144,9 @@ module SSHKit
     def environment_string
       environment_hash.collect do |key,value|
         if key.is_a? Symbol
-          "#{key.to_s.upcase}=#{value}"
+          "#{key.to_s.upcase}=\"#{value.to_s.gsub(/"/, '\"')}\""
         else
-          "#{key.to_s}=#{value}"
+          "#{key.to_s}=\"#{value.to_s.gsub(/"/, '\"')}\""
         end
       end.join(' ')
     end

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -28,19 +28,19 @@ module SSHKit
     def test_including_the_env
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {rails_env: :production})
-      assert_equal "( RAILS_ENV=\"production\" /usr/bin/env rails server )", c.to_command
+      assert_equal %{( RAILS_ENV="production" /usr/bin/env rails server )}, c.to_command
     end
 
     def test_including_the_env_with_multiple_keys
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {rails_env: :production, foo: 'bar'})
-      assert_equal "( RAILS_ENV=\"production\" FOO=\"bar\" /usr/bin/env rails server )", c.to_command
+      assert_equal %{( RAILS_ENV="production" FOO="bar" /usr/bin/env rails server )}, c.to_command
     end
 
     def test_including_the_env_with_string_keys
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {'FACTER_env' => :production, foo: 'bar'})
-      assert_equal "( FACTER_env=\"production\" FOO=\"bar\" /usr/bin/env rails server )", c.to_command
+      assert_equal %{( FACTER_env="production" FOO="bar" /usr/bin/env rails server )}, c.to_command
     end
 
     def test_double_quotes_are_escaped_in_env
@@ -52,20 +52,20 @@ module SSHKit
     def test_including_the_env_doesnt_addressively_escape
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {path: '/example:$PATH'})
-      assert_equal "( PATH=\"/example:$PATH\" /usr/bin/env rails server )", c.to_command
+      assert_equal %{( PATH="/example:$PATH" /usr/bin/env rails server )}, c.to_command
     end
 
     def test_global_env
       SSHKit.config = nil
       SSHKit.config.default_env = { default: 'env' }
       c = Command.new(:rails, 'server', env: {})
-      assert_equal "( DEFAULT=\"env\" /usr/bin/env rails server )", c.to_command
+      assert_equal %{( DEFAULT="env" /usr/bin/env rails server )}, c.to_command
     end
 
     def test_default_env_is_overwritten_with_locally_defined
       SSHKit.config.default_env = { foo: 'bar', over: 'under' }
       c = Command.new(:rails, 'server', env: { over: 'write'})
-      assert_equal "( FOO=\"bar\" OVER=\"write\" /usr/bin/env rails server )", c.to_command
+      assert_equal %{( FOO="bar" OVER="write" /usr/bin/env rails server )}, c.to_command
     end
 
     def test_working_in_a_given_directory
@@ -75,7 +75,7 @@ module SSHKit
 
     def test_working_in_a_given_directory_with_env
       c = Command.new(:ls, '-l', in: "/opt/sites", env: {a: :b})
-      assert_equal "cd /opt/sites && ( A=\"b\" /usr/bin/env ls -l )", c.to_command
+      assert_equal %{cd /opt/sites && ( A="b" /usr/bin/env ls -l )}, c.to_command
     end
 
     def test_having_a_host_passed
@@ -120,7 +120,7 @@ module SSHKit
     def test_umask_with_env_and_working_directory_and_user
       SSHKit.config.umask = '007'
       c = Command.new(:touch, 'somefile', user: 'bob', env: {a: 'b'}, in: '/var')
-      assert_equal "cd /var && umask 007 && ( A=\"b\" sudo -u bob A=\"b\" -- sh -c '/usr/bin/env touch somefile' )", c.to_command
+      assert_equal %{cd /var && umask 007 && ( A="b" sudo -u bob A="b" -- sh -c '/usr/bin/env touch somefile' )}, c.to_command
     end
 
     def test_verbosity_defaults_to_logger_info

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -28,38 +28,44 @@ module SSHKit
     def test_including_the_env
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {rails_env: :production})
-      assert_equal "( RAILS_ENV=production /usr/bin/env rails server )", c.to_command
+      assert_equal "( RAILS_ENV=\"production\" /usr/bin/env rails server )", c.to_command
     end
 
     def test_including_the_env_with_multiple_keys
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {rails_env: :production, foo: 'bar'})
-      assert_equal "( RAILS_ENV=production FOO=bar /usr/bin/env rails server )", c.to_command
+      assert_equal "( RAILS_ENV=\"production\" FOO=\"bar\" /usr/bin/env rails server )", c.to_command
     end
 
     def test_including_the_env_with_string_keys
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {'FACTER_env' => :production, foo: 'bar'})
-      assert_equal "( FACTER_env=production FOO=bar /usr/bin/env rails server )", c.to_command
+      assert_equal "( FACTER_env=\"production\" FOO=\"bar\" /usr/bin/env rails server )", c.to_command
+    end
+
+    def test_double_quotes_are_escaped_in_env
+      SSHKit.config = nil
+      c = Command.new(:rails, 'server', env: {foo: 'asdf"hjkl'})
+      assert_equal %{( FOO="asdf\\\"hjkl" /usr/bin/env rails server )}, c.to_command
     end
 
     def test_including_the_env_doesnt_addressively_escape
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {path: '/example:$PATH'})
-      assert_equal "( PATH=/example:$PATH /usr/bin/env rails server )", c.to_command
+      assert_equal "( PATH=\"/example:$PATH\" /usr/bin/env rails server )", c.to_command
     end
 
     def test_global_env
       SSHKit.config = nil
       SSHKit.config.default_env = { default: 'env' }
       c = Command.new(:rails, 'server', env: {})
-      assert_equal "( DEFAULT=env /usr/bin/env rails server )", c.to_command
+      assert_equal "( DEFAULT=\"env\" /usr/bin/env rails server )", c.to_command
     end
 
     def test_default_env_is_overwritten_with_locally_defined
       SSHKit.config.default_env = { foo: 'bar', over: 'under' }
       c = Command.new(:rails, 'server', env: { over: 'write'})
-      assert_equal "( FOO=bar OVER=write /usr/bin/env rails server )", c.to_command
+      assert_equal "( FOO=\"bar\" OVER=\"write\" /usr/bin/env rails server )", c.to_command
     end
 
     def test_working_in_a_given_directory
@@ -69,7 +75,7 @@ module SSHKit
 
     def test_working_in_a_given_directory_with_env
       c = Command.new(:ls, '-l', in: "/opt/sites", env: {a: :b})
-      assert_equal "cd /opt/sites && ( A=b /usr/bin/env ls -l )", c.to_command
+      assert_equal "cd /opt/sites && ( A=\"b\" /usr/bin/env ls -l )", c.to_command
     end
 
     def test_having_a_host_passed
@@ -114,7 +120,7 @@ module SSHKit
     def test_umask_with_env_and_working_directory_and_user
       SSHKit.config.umask = '007'
       c = Command.new(:touch, 'somefile', user: 'bob', env: {a: 'b'}, in: '/var')
-      assert_equal "cd /var && umask 007 && ( A=b sudo -u bob A=b -- sh -c '/usr/bin/env touch somefile' )", c.to_command
+      assert_equal "cd /var && umask 007 && ( A=\"b\" sudo -u bob A=\"b\" -- sh -c '/usr/bin/env touch somefile' )", c.to_command
     end
 
     def test_verbosity_defaults_to_logger_info


### PR DESCRIPTION
Ran into an issue this week with an environment variable which contained special shell characters, and broke deploys.

I was going to solve this with `Shellwords.escape`, but found that also escapes '$'.

I ended up taking the approach from #156 and bringing it up to date with master.

@leehambley You okay with this approach?