### PR TITLE
interaction_handler: Don't put response_data on log

### DIFF
--- a/lib/sshkit/mapping_interaction_handler.rb
+++ b/lib/sshkit/mapping_interaction_handler.rb
@@ -36,7 +36,7 @@ module SSHKit
       if response_data.nil?
         output.debug("Unable to find interaction handler mapping for #{stream_name}: #{data.inspect} so no response was sent")
       else
-        output.debug("Sending #{response_data.inspect}")
+        output.debug("Sending response data")
         if channel.respond_to?(:send_data) # Net SSH Channel
           channel.send_data(response_data)
         elsif channel.respond_to?(:write) # Local IO


### PR DESCRIPTION
interaction_handler is great. but I want keeping use `debug` level logging to get command's output, but when interaction_handler feature puts content of sending data to debug log with message `Sending`.

data sent using interaction_handler may contain sensitive data, so please reconsider logging content by default. Note that the default log level is set to `debug`.