### PR TITLE
Introduce explicit command logging methods and deprecate stdout / stderr Command attrs

### DIFF
--- a/BREAKING_API_WISHLIST.md
+++ b/BREAKING_API_WISHLIST.md
@@ -5,6 +5,10 @@ which could be considered at the next major release.
 
 * Consider no longer stripping by default on `capture` [#249](https://github.com/capistrano/sshkit/pull/249)
 
-## Deprecated methods which could be deleted in a future major release
+## Deprecated code which could be deleted in a future major release
 
-* [Abstract.background](lib/sshkit/backends/abstract.rb#L43)
+* [Abstract.background method](lib/sshkit/backends/abstract.rb#L43)
+* [`@stderr`, `@stdout` attrs on `Command`](lib/sshkit/command.rb#L28)
+
+## Cleanup when Ruby 1.9 support is dropped
+* `to_a` can probably be removed from `"str".lines.to_a`, since `"str".lines` returns an `Array` under Ruby 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ appear at the top.
 
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * Introduce `log_command_start`, `log_command_data`, `log_command_exit` methods on `Formatter`
+    [PR #257](https://github.com/capistrano/sshkit/pull/257)
+    @robd
+    * Deprecate `@stdout` and `@stderr` accessors on `Command`
   * Add support for deprecation logging options.
     [README](README.md#deprecation-warnings),
     [PR #258](https://github.com/capistrano/sshkit/pull/258)
+    @robd
   * Quote environment variable values.
     [PR #250](https://github.com/capistrano/sshkit/pull/250)
     @Sinjo - Chris Sinjakli

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -57,8 +57,6 @@ module SSHKit
           stderr_thread.join
 
           cmd.exit_status = wait_thr.value.to_i
-          cmd.clear_stdout_lines
-          cmd.clear_stderr_lines
 
           output.log_command_exit(cmd)
         end

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -34,7 +34,7 @@ module SSHKit
       private
 
       def execute_command(cmd)
-        output << cmd
+        output.log_command_start(cmd)
 
         cmd.started = Time.now
 
@@ -42,14 +42,14 @@ module SSHKit
           stdout_thread = Thread.new do
             while line = stdout.gets do
               cmd.on_stdout(stdin, line)
-              output << cmd
+              output.log_command_data(cmd, :stdout, line)
             end
           end
 
           stderr_thread = Thread.new do
             while line = stderr.gets do
               cmd.on_stderr(stdin, line)
-              output << cmd
+              output.log_command_data(cmd, :stderr, line)
             end
           end
 
@@ -60,7 +60,7 @@ module SSHKit
           cmd.clear_stdout_lines
           cmd.clear_stderr_lines
 
-          output << cmd
+          output.log_command_exit(cmd)
         end
       end
 

--- a/lib/sshkit/backends/printer.rb
+++ b/lib/sshkit/backends/printer.rb
@@ -5,7 +5,7 @@ module SSHKit
     class Printer < Abstract
 
       def execute_command(cmd)
-        output << cmd
+        output.log_command_start(cmd)
       end
 
       alias :upload! :execute

--- a/lib/sshkit/formatters/abstract.rb
+++ b/lib/sshkit/formatters/abstract.rb
@@ -23,10 +23,25 @@ module SSHKit
       end
       alias :log :info
 
+      def log_command_start(command)
+        write(command)
+      end
+
+      def log_command_data(command, stream_type, stream_data)
+        write(command)
+      end
+
+      def log_command_exit(command)
+        write(command)
+      end
+
+      def <<(obj)
+        write(obj)
+      end
+
       def write(obj)
         raise "Abstract formatter should not be used directly, maybe you want SSHKit::Formatter::BlackHole"
       end
-      alias :<< :write
 
     end
 

--- a/lib/sshkit/formatters/black_hole.rb
+++ b/lib/sshkit/formatters/black_hole.rb
@@ -7,7 +7,6 @@ module SSHKit
       def write(obj)
         # Nothing, nothing to do
       end
-      alias :<< :write
 
     end
 

--- a/lib/sshkit/formatters/dot.rb
+++ b/lib/sshkit/formatters/dot.rb
@@ -10,7 +10,6 @@ module SSHKit
           original_output << colorize('.', obj.failure? ? :red : :green)
         end
       end
-      alias :<< :write
 
     end
 

--- a/lib/sshkit/formatters/dot.rb
+++ b/lib/sshkit/formatters/dot.rb
@@ -4,11 +4,11 @@ module SSHKit
 
     class Dot < Abstract
 
+      def log_command_exit(command)
+        original_output << colorize('.', command.failure? ? :red : :green)
+      end
+
       def write(obj)
-        return unless obj.is_a? SSHKit::Command
-        if obj.finished?
-          original_output << colorize('.', obj.failure? ? :red : :green)
-        end
       end
 
     end

--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -8,7 +8,6 @@ module SSHKit
       LEVEL_COLORS = [:black, :blue, :yellow, :red, :red].freeze
 
       def write(obj)
-        return if obj.respond_to?(:verbosity) && obj.verbosity < SSHKit.config.output_verbosity
         case obj
         when SSHKit::Command    then write_command(obj)
         when SSHKit::LogMessage then write_message(obj.verbosity, obj.to_s)
@@ -35,7 +34,7 @@ module SSHKit
           host_prefix = command.host.user ? "as #{colorize(command.host.user, :blue)}@" : 'on '
           message = "Running #{colorize(command, :yellow, :bold)} #{host_prefix}#{colorize(command.host, :blue)}"
           write_message(command.verbosity, message, uuid)
-          write_debug("Command: #{colorize(command.to_command, :blue)}", uuid)
+          write_message(Logger::DEBUG, "Command: #{colorize(command.to_command, :blue)}", uuid)
         end
 
         write_std_stream_debug(command.clear_stdout_lines, :green, uuid)
@@ -51,16 +50,12 @@ module SSHKit
 
       def write_std_stream_debug(lines, color, uuid)
         lines.each do |line|
-          write_debug(colorize("\t#{line}".chomp, color), uuid)
+          write_message(Logger::DEBUG, colorize("\t#{line}".chomp, color), uuid)
         end
       end
 
-      def write_debug(message, uuid)
-        write_message(Logger::DEBUG, message, uuid) if SSHKit.config.output_verbosity == Logger::DEBUG
-      end
-
       def write_message(verbosity, message, uuid=nil)
-        original_output << "#{format_message(verbosity, message, uuid)}\n"
+        original_output << "#{format_message(verbosity, message, uuid)}\n" if verbosity >= SSHKit.config.output_verbosity
       end
 
     end

--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -17,7 +17,6 @@ module SSHKit
                 "called with #{obj.class}: #{obj.inspect}"
         end
       end
-      alias :<< :write
 
       protected
 

--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -8,13 +8,34 @@ module SSHKit
       LEVEL_COLORS = [:black, :blue, :yellow, :red, :red].freeze
 
       def write(obj)
-        case obj
-        when SSHKit::Command    then write_command(obj)
-        when SSHKit::LogMessage then write_message(obj.verbosity, obj.to_s)
+        if obj.kind_of?(SSHKit::LogMessage)
+          write_message(obj.verbosity, obj.to_s)
         else
-          raise "Output formatter only supports formatting SSHKit::Command and SSHKit::LogMessage, " \
-                "called with #{obj.class}: #{obj.inspect}"
+          raise "write only supports formatting SSHKit::LogMessage, called with #{obj.class}: #{obj.inspect}"
         end
+      end
+
+      def log_command_start(command)
+        host_prefix = command.host.user ? "as #{colorize(command.host.user, :blue)}@" : 'on '
+        message = "Running #{colorize(command, :yellow, :bold)} #{host_prefix}#{colorize(command.host, :blue)}"
+        write_message(command.verbosity, message, command.uuid)
+        write_message(Logger::DEBUG, "Command: #{colorize(command.to_command, :blue)}", command.uuid)
+      end
+
+      def log_command_data(command, stream_type, stream_data)
+        color = case stream_type
+          when :stdout then :green
+          when :stderr then :red
+          else raise "Unrecognised stream_type #{stream_type}, expected :stdout or :stderr"
+        end
+        write_message(Logger::DEBUG, colorize("\t#{stream_data}".chomp, color), command.uuid)
+      end
+
+      def log_command_exit(command)
+        runtime = sprintf('%5.3f seconds', command.runtime)
+        successful_or_failed =  command.failure? ? colorize('failed', :red, :bold) : colorize('successful', :green, :bold)
+        message = "Finished in #{runtime} with exit status #{command.exit_status} (#{successful_or_failed})."
+        write_message(command.verbosity, message, command.uuid)
       end
 
       protected
@@ -26,33 +47,6 @@ module SSHKit
       end
 
       private
-
-      def write_command(command)
-        uuid = command.uuid
-
-        unless command.started?
-          host_prefix = command.host.user ? "as #{colorize(command.host.user, :blue)}@" : 'on '
-          message = "Running #{colorize(command, :yellow, :bold)} #{host_prefix}#{colorize(command.host, :blue)}"
-          write_message(command.verbosity, message, uuid)
-          write_message(Logger::DEBUG, "Command: #{colorize(command.to_command, :blue)}", uuid)
-        end
-
-        write_std_stream_debug(command.clear_stdout_lines, :green, uuid)
-        write_std_stream_debug(command.clear_stderr_lines, :red, uuid)
-
-        if command.finished?
-          runtime = sprintf('%5.3f seconds', command.runtime)
-          successful_or_failed =  command.failure? ? colorize('failed', :red, :bold) : colorize('successful', :green, :bold)
-          message = "Finished in #{runtime} with exit status #{command.exit_status} (#{successful_or_failed})."
-          write_message(command.verbosity, message, uuid)
-        end
-      end
-
-      def write_std_stream_debug(lines, color, uuid)
-        lines.each do |line|
-          write_message(Logger::DEBUG, colorize("\t#{line}".chomp, color), uuid)
-        end
-      end
 
       def write_message(verbosity, message, uuid=nil)
         original_output << "#{format_message(verbosity, message, uuid)}\n" if verbosity >= SSHKit.config.output_verbosity

--- a/test/unit/formatters/test_custom.rb
+++ b/test/unit/formatters/test_custom.rb
@@ -1,0 +1,65 @@
+require 'helper'
+
+module SSHKit
+  # Try to maintain backwards compatibility with Custom formatters defined by other people
+  class TestCustom < UnitTest
+
+    def setup
+      super
+      SSHKit.config.output_verbosity = Logger::DEBUG
+    end
+
+    def output
+      @output ||= String.new
+    end
+
+    def custom
+      @custom ||= CustomFormatter.new(output)
+    end
+
+    {
+        log:   'LM 1 Test',
+        fatal: 'LM 4 Test',
+        error: 'LM 3 Test',
+        warn:  'LM 2 Test',
+        info:  'LM 1 Test',
+        debug: 'LM 0 Test'
+    }.each do |level, expected_output|
+      define_method("test_#{level}_logging") do
+        custom.send(level, 'Test')
+        assert_log_output expected_output
+      end
+    end
+
+    def test_write_logs_commands
+      custom.write(Command.new(:ls))
+
+      assert_log_output 'C 1 /usr/bin/env ls'
+    end
+
+    def test_double_chevron_logs_commands
+      custom << Command.new(:ls)
+
+      assert_log_output 'C 1 /usr/bin/env ls'
+    end
+
+    private
+
+    def assert_log_output(expected_output)
+      assert_equal expected_output, output
+    end
+
+  end
+
+  class CustomFormatter < SSHKit::Formatter::Abstract
+    def write(obj)
+      original_output << case obj
+        when SSHKit::Command    then "C #{obj.verbosity} #{obj}"
+        when SSHKit::LogMessage then "LM #{obj.verbosity} #{obj}"
+      end
+    end
+    alias :<< :write
+
+  end
+
+end

--- a/test/unit/formatters/test_dot.rb
+++ b/test/unit/formatters/test_dot.rb
@@ -23,9 +23,13 @@ module SSHKit
       end
     end
 
-    def test_unfinished_command
-      command = SSHKit::Command.new(:ls)
-      dot << command
+    def test_log_command_start
+      dot.log_command_start(SSHKit::Command.new(:ls))
+      assert_log_output('')
+    end
+
+    def test_log_command_data
+      dot.log_command_data(SSHKit::Command.new(:ls), :stdout, 'Some output')
       assert_log_output('')
     end
 
@@ -33,7 +37,7 @@ module SSHKit
       output.stubs(:tty?).returns(true)
       command = SSHKit::Command.new(:ls)
       command.exit_status = 0
-      dot << command
+      dot.log_command_exit(command)
       assert_log_output("\e[0;32;49m.\e[0m")
     end
 
@@ -41,13 +45,8 @@ module SSHKit
       output.stubs(:tty?).returns(true)
       command = SSHKit::Command.new(:ls, {raise_on_non_zero_exit: false})
       command.exit_status = 1
-      dot << command
+      dot.log_command_exit(command)
       assert_log_output("\e[0;31;49m.\e[0m")
-    end
-
-    def test_unsupported_class
-      dot << Pathname.new('/tmp')
-      assert_log_output('')
     end
 
     private

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -115,15 +115,14 @@ module SSHKit
       command = SSHKit::Command.new(:a_cmd, 'some args', host: Host.new('user@localhost'))
       command.stubs(:uuid).returns('aaaaaa')
       command.stubs(:runtime).returns(1)
-      pretty << command
+      pretty.log_command_start(command)
       command.started = true
-      pretty << command
       command.on_stdout(nil, 'stdout message')
-      pretty << command
+      pretty.log_command_data(command, :stdout, 'stdout message')
       command.on_stderr(nil, 'stderr message')
-      pretty << command
+      pretty.log_command_data(command, :stderr, 'stderr message')
       command.exit_status = 0
-      pretty << command
+      pretty.log_command_exit(command)
     end
 
     def assert_log_output(expected_output)

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -88,7 +88,7 @@ module SSHKit
       raised_error = assert_raises RuntimeError do
         pretty << Pathname.new('/tmp')
       end
-      assert_equal('Output formatter only supports formatting SSHKit::Command and SSHKit::LogMessage, called with Pathname: #<Pathname:/tmp>', raised_error.message)
+      assert_equal('write only supports formatting SSHKit::LogMessage, called with Pathname: #<Pathname:/tmp>', raised_error.message)
     end
 
     def test_does_not_log_message_when_verbosity_is_too_low

--- a/test/unit/formatters/test_simple_text.rb
+++ b/test/unit/formatters/test_simple_text.rb
@@ -61,7 +61,7 @@ module SSHKit
       raised_error = assert_raises RuntimeError do
         simple << Pathname.new('/tmp')
       end
-      assert_equal('Output formatter only supports formatting SSHKit::Command and SSHKit::LogMessage, called with Pathname: #<Pathname:/tmp>', raised_error.message)
+      assert_equal('write only supports formatting SSHKit::LogMessage, called with Pathname: #<Pathname:/tmp>', raised_error.message)
     end
 
     def test_does_not_log_when_verbosity_is_too_low

--- a/test/unit/formatters/test_simple_text.rb
+++ b/test/unit/formatters/test_simple_text.rb
@@ -38,15 +38,14 @@ module SSHKit
       command.stubs(:uuid).returns('aaaaaa')
       command.stubs(:runtime).returns(1)
 
-      simple << command
+      simple.log_command_start(command)
       command.started = true
-      simple << command
       command.on_stdout(nil, 'stdout message')
-      simple << command
+      simple.log_command_data(command, :stdout, 'stdout message')
       command.on_stderr(nil, 'stderr message')
-      simple << command
+      simple.log_command_data(command, :stderr, 'stderr message')
       command.exit_status = 0
-      simple << command
+      simple.log_command_exit(command)
 
       expected_log_lines = [
         'Running /usr/bin/env a_cmd some args as user@localhost',

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -168,19 +168,46 @@ module SSHKit
     def test_on_stdout
       c = Command.new(:whoami)
       c.on_stdout(nil, "test\n")
-      assert_equal ["test\n"], c.clear_stdout_lines
+      c.on_stdout(nil, 'test2')
+      c.on_stdout(nil, 'test3')
+      assert_equal "test\ntest2test3", c.full_stdout
     end
 
     def test_on_stderr
       c = Command.new(:whoami)
-      c.on_stderr(nil, "test\n")
-      assert_equal ["test\n"], c.clear_stderr_lines
+      c.on_stderr(nil, 'test')
+      assert_equal 'test', c.full_stderr
     end
 
-    def test_clear_lines_methods_return_empty_array_when_blank
-      command = Command.new(:some_command)
-      assert_equal [], command.clear_stdout_lines
-      assert_equal [], command.clear_stderr_lines
+    def test_deprecated_stdtream_accessors
+      deprecation_out = ''
+      SSHKit.config.deprecation_output = deprecation_out
+
+      c = Command.new(:whoami)
+      c.stdout='a test'
+      assert_equal('a test', c.stdout)
+      c.stderr='another test'
+      assert_equal('another test', c.stderr)
+      deprecation_lines = deprecation_out.lines.to_a
+
+      assert_equal 8, deprecation_lines.size
+      assert_equal(
+        '[Deprecated] The stdout= method on Command is deprecated. ' +
+        "The @stdout attribute will be removed in a future release.\n",
+        deprecation_lines[0])
+      assert_equal(
+        '[Deprecated] The stdout method on Command is deprecated. ' +
+        "The @stdout attribute will be removed in a future release. Use full_stdout() instead.\n",
+        deprecation_lines[2])
+
+      assert_equal(
+        '[Deprecated] The stderr= method on Command is deprecated. ' +
+        "The @stderr attribute will be removed in a future release.\n",
+        deprecation_lines[4])
+      assert_equal(
+        '[Deprecated] The stderr method on Command is deprecated. ' +
+        "The @stderr attribute will be removed in a future release. Use full_stderr() instead.\n",
+        deprecation_lines[6])
     end
 
     def test_setting_exit_status


### PR DESCRIPTION
At the moment, one of the hardest bits of code to understand, and the source of some historical bugs, is the [`@stdout`, `@stderr`](https://github.com/capistrano/sshkit/blob/1a7c69f56ef8a60c4df5b411124d6c935cefe665/lib/sshkit/command.rb#L28) attributes on command. These are used as a temporary buffer of the latest unconsumed output lines by the formatters. The backends append to the buffer ([netssh](https://github.com/capistrano/sshkit/blob/1a7c69f56ef8a60c4df5b411124d6c935cefe665/lib/sshkit/backends/netssh.rb#L92), [local](https://github.com/capistrano/sshkit/blob/1a7c69f56ef8a60c4df5b411124d6c935cefe665/lib/sshkit/backends/local.rb#L44)) via the [on_stdout](https://github.com/capistrano/sshkit/blob/1a7c69f56ef8a60c4df5b411124d6c935cefe665/lib/sshkit/command.rb#L60) and [on_stderr](https://github.com/capistrano/sshkit/blob/1a7c69f56ef8a60c4df5b411124d6c935cefe665/lib/sshkit/command.rb#L70) methods, and then the pretty formatter [clears the buffers](https://github.com/capistrano/sshkit/blob/1a7c69f56ef8a60c4df5b411124d6c935cefe665/lib/sshkit/formatters/pretty.rb#L42-L43) via the [clear_stdout_lines](https://github.com/capistrano/sshkit/blob/1a7c69f56ef8a60c4df5b411124d6c935cefe665/lib/sshkit/command.rb#L65) and [clear_stderr_lines](https://github.com/capistrano/sshkit/blob/1a7c69f56ef8a60c4df5b411124d6c935cefe665/lib/sshkit/command.rb#L75) methods.

As well as being hard to understand, it makes integrating with SSHKit harder. For example, Airbrussh has to [dup the `Command`](https://github.com/mattbrictson/airbrussh/blob/85e4454492d2470ca20258163ed15d570332e439/lib/airbrussh/formatter.rb#L84) in order to make sure that stdout/stderr are not cleared by the pretty formatter.

In order to fix this, I propose to widen the `Formatter` API and include 3 specific methods (`log_command_start`, `log_command_data`, `log_command_exit`) for logging the different command states rather than switching on the internal state in `Command`. 

The other state on `Command` (ie :started_at, :started, :exit_status, :full_stdout, :full_stderr) is less confusing because at least this state is all being set by the backends, and simply read by the formatters (rather than mutated). I propose to leave these for the moment.

As part of this, I'd like to deprecate `@stdout` and `@stderr` on `Command` to explain the changes to people who use the stdout / stderr accessors. (I deleted these previously, but I will reinstate them with deprecation warnings). In order to do this, I am intending to write a de-duplicating deprecator and introduce a new config option - `SSHKit.config.deprecation_output` which takes the same sort of object as the normal output (ie one which implements `<<`). By default, I propose to log deprecation directly to `stderr`. This means deprecation errors will show up for people using formatters which hide normal warnings (eg `Dot` or `BlackHole`). Deprecation warnings can easily be disabled:

```ruby
# Supress deprecation warnings
SSHKit.config.deprecation_output = nil

SSHKit.config.deprecation_output = File.open('log/dep_warnings.log', 'wb')
```

@mattbrictson I discussed I had some ideas for this a while ago. If you don't mind, can you look at the new formatter methods and see what you think?

@leehambley Would value your thoughts on this as always.


