### PR TITLE
Add support for deprecation_output config and DeprecationLogger

### DIFF
--- a/BREAKING_API_WISHLIST.md
+++ b/BREAKING_API_WISHLIST.md
@@ -4,3 +4,7 @@ SSHKit respects semantic versioning. This file is a place to record breaking API
 which could be considered at the next major release.
 
 * Consider no longer stripping by default on `capture` [#249](https://github.com/capistrano/sshkit/pull/249)
+
+## Deprecated methods which could be deleted in a future major release
+
+* [Abstract.background](lib/sshkit/backends/abstract.rb#L43)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ appear at the top.
 
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * Add support for deprecation logging options.
+    [README](README.md#deprecation-warnings),
+    [PR #258](https://github.com/capistrano/sshkit/pull/258)
   * Quote environment variable values.
     [PR #250](https://github.com/capistrano/sshkit/pull/250)
     @Sinjo - Chris Sinjakli

--- a/README.md
+++ b/README.md
@@ -472,6 +472,19 @@ and defaults to `Logger::INFO`.
 
 At present the `Logger::WARN`, `ERROR` and `FATAL` are not used.
 
+## Deprecation warnings
+
+Deprecation warnings are logged directly to `stderr` by default. This behaviour
+can be changed by setting the `SSHKit.config.deprecation_output` option:
+
+```ruby
+# Disable deprecation warnings
+SSHKit.config.deprecation_output = nil
+
+# Log deprecation warnings to a file
+SSHKit.config.deprecation_output = File.open('log/deprecation_warnings.log', 'wb')
+```
+
 ## Connection Pooling
 
 SSHKit uses a simple connection pool (enabled by default) to reduce the

--- a/lib/sshkit/all.rb
+++ b/lib/sshkit/all.rb
@@ -9,6 +9,8 @@ require_relative 'command_map'
 require_relative 'configuration'
 require_relative 'coordinator'
 
+require_relative 'deprecation_logger'
+
 require_relative 'exception'
 
 require_relative 'logger'

--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -41,7 +41,9 @@ module SSHKit
       end
 
       def background(*args)
-        warn "[Deprecated] The background method is deprecated. Blame badly behaved pseudo-daemons!"
+        SSHKit.config.deprecation_logger.log(
+          'The background method is deprecated. Blame badly behaved pseudo-daemons!'
+        )
         options = args.extract_options!.merge(run_in_background: true)
         create_command_and_execute(args, options).success?
       end

--- a/lib/sshkit/configuration.rb
+++ b/lib/sshkit/configuration.rb
@@ -9,6 +9,15 @@ module SSHKit
       @output ||= formatter(:pretty)
     end
 
+    def deprecation_logger
+      self.deprecation_output = $stderr if @deprecation_logger.nil?
+      @deprecation_logger
+    end
+
+    def deprecation_output=(out)
+      @deprecation_logger = DeprecationLogger.new(out)
+    end
+
     def default_env
       @default_env ||= {}
     end

--- a/lib/sshkit/deprecation_logger.rb
+++ b/lib/sshkit/deprecation_logger.rb
@@ -1,0 +1,17 @@
+module SSHKit
+  class DeprecationLogger
+    def initialize(out)
+      @out = out
+      @previous_warnings = Set.new
+    end
+
+    def log(message)
+      return if @out.nil?
+      warning_msg = "[Deprecated] #{message}\n"
+      caller_line = caller.find { |caller_line| !caller_line.include?('lib/sshkit') }
+      warning_msg << "    (Called from #{caller_line})\n" unless caller_line.nil?
+      @out << warning_msg unless @previous_warnings.include?(warning_msg)
+      @previous_warnings << warning_msg
+    end
+  end
+end

--- a/test/unit/backends/test_abstract.rb
+++ b/test/unit/backends/test_abstract.rb
@@ -77,6 +77,22 @@ module SSHKit
         assert_equal "Some stdout\n     ", output
       end
 
+      def test_background_logs_deprecation_warnings
+        deprecation_out = ''
+        SSHKit.config.deprecation_output = deprecation_out
+
+        ExampleBackend.new do
+          background :ls
+        end.run
+
+        lines = deprecation_out.lines.to_a
+
+        assert_equal 2, lines.length
+
+        assert_equal("[Deprecated] The background method is deprecated. Blame badly behaved pseudo-daemons!\n", lines[0])
+        assert_match(/    \(Called from.*test_abstract.rb:\d+:in `block in test_background_logs_deprecation_warnings'\)\n/, lines[1])
+      end
+
       def test_calling_abstract_with_undefined_execute_command_raises_exception
         abstract =  Abstract.new(ExampleBackend.example_host) do
           execute(:some_command)

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -10,6 +10,22 @@ module SSHKit
       SSHKit.config.output = SSHKit::Formatter::Pretty.new($stdout)
     end
 
+    def test_deprecation_output
+      output = ''
+      SSHKit.config.deprecation_output = output
+      SSHKit.config.deprecation_logger.log('Test')
+      assert_equal "[Deprecated] Test\n", output.lines.first
+    end
+
+    def test_default_deprecation_output
+      SSHKit.config.deprecation_logger.log('Test')
+    end
+
+    def test_nil_deprecation_output
+      SSHKit.config.deprecation_output = nil
+      SSHKit.config.deprecation_logger.log('Test')
+    end
+
     def test_output
       assert SSHKit.config.output.is_a? SSHKit::Formatter::Pretty
       assert SSHKit.config.output = $stderr

--- a/test/unit/test_deprecation_logger.rb
+++ b/test/unit/test_deprecation_logger.rb
@@ -1,0 +1,38 @@
+require 'helper'
+
+module SSHKit
+
+  class TestDeprecationLogger < UnitTest
+
+    def output
+      @output ||= String.new
+    end
+
+    def logger
+      @logger ||= DeprecationLogger.new(output)
+    end
+
+    def test_hides_duplicate_deprecation_warnings
+      line_number = generate_warning
+      generate_warning
+
+      actual_lines = output.lines.to_a
+
+      assert_equal(2, actual_lines.size)
+      assert_equal "[Deprecated] Some message\n", actual_lines[0]
+      assert_match %r{    \(Called from .*sshkit/test/unit/test_deprecation_logger.rb:#{line_number}:in `generate_warning'\)\n}, actual_lines[1]
+    end
+
+    def test_handles_nil_output
+      DeprecationLogger.new(nil).log('Some message')
+    end
+
+    private
+
+    def generate_warning
+      logger.log('Some message')
+      __LINE__-1
+    end
+  end
+
+end


### PR DESCRIPTION
Further to #257, this PR adds support for a DeprecationLogger and related configuration.