### PR TITLE
Combine on_stdout and on_stderr into on_data on interaction handler api

### DIFF
--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -79,13 +79,13 @@ module SSHKit
     def on_stdout(channel, data)
       @stdout = data
       @full_stdout += data
-      call_interaction_handler(channel, data, :on_stdout)
+      call_interaction_handler(:stdout, data, channel)
     end
 
     def on_stderr(channel, data)
       @stderr = data
       @full_stderr += data
-      call_interaction_handler(channel, data, :on_stderr)
+      call_interaction_handler(:stderr, data, channel)
     end
 
     def exit_status=(new_exit_status)
@@ -230,10 +230,10 @@ module SSHKit
       end
     end
 
-    def call_interaction_handler(channel, data, callback_name)
+    def call_interaction_handler(stream_name, data, channel)
       interaction_handler = options[:interaction_handler]
       interaction_handler = MappingInteractionHandler.new(interaction_handler) if interaction_handler.kind_of?(Hash)
-      interaction_handler.send(callback_name, channel, data, self) if interaction_handler.respond_to?(callback_name)
+      interaction_handler.on_data(self, stream_name, data, channel) if interaction_handler.respond_to?(:on_data)
     end
 
     def log_reader_deprecation(stream)

--- a/lib/sshkit/mapping_interaction_handler.rb
+++ b/lib/sshkit/mapping_interaction_handler.rb
@@ -17,17 +17,7 @@ module SSHKit
       end
     end
 
-    def on_stdout(channel, data, command)
-      on_data(channel, data, 'stdout')
-    end
-
-    def on_stderr(channel, data, command)
-      on_data(channel, data, 'stderr')
-    end
-
-    private
-
-    def on_data(channel, data, stream_name)
+    def on_data(command, stream_name, data, channel)
       log("Looking up response for #{stream_name} message #{data.inspect}")
 
       response_data = @mapping_proc.call(data)
@@ -45,6 +35,8 @@ module SSHKit
         end
       end
     end
+
+    private
 
     def log(message)
       SSHKit.config.output.send(@log_level, message) unless @log_level.nil?


### PR DESCRIPTION
The current `interaction handler` API is overly complex, requiring users to implement both `on_stdout` and `on_stderr`. In many cases, you don't care which stream the data is arriving on. 

Therefore I propose to replace two methods (`on_stdout` and `on_stderr`) with a single `on_data` method. The `stream_name` (`:stdout` or `:stderr`) is now passed as a parameter so can still be used if the user needs to distinguish between the two.

If people are agreed that the single method API is better, we might as well fix this now before the `interaction_handler` API is officially released.