### PR TITLE
Escape percentage sign in env variables

### DIFF
--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -156,7 +156,7 @@ module SSHKit
     def environment_string
       environment_hash.collect do |key,value|
         key_string = key.is_a?(Symbol) ? key.to_s.upcase : key.to_s
-        escaped_value = value.to_s.gsub(/"/, '\"')
+        escaped_value = value.to_s.gsub(/"/, '\"').gsub("%", "%%")
         %{#{key_string}="#{escaped_value}"}
       end.join(' ')
     end

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -49,6 +49,12 @@ module SSHKit
       assert_equal %{( FOO="asdf\\\"hjkl" /usr/bin/env rails server )}, c.to_command
     end
 
+    def test_percent_signs_are_escaped_in_env
+      SSHKit.config = nil
+      c = Command.new(:rails, 'server', env: {foo: 'asdf%hjkl'})
+      assert_equal %{( FOO="asdf%hjkl" /usr/bin/env rails server )}, c.to_command
+    end
+
     def test_including_the_env_doesnt_addressively_escape
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {path: '/example:$PATH'})


### PR DESCRIPTION
Before:

`ArgumentError: invalid value for Integer(): "/usr/bin/env git fetch origin"` if env variable has percentage sign in it

Now:

works fine.

I guess inside `within` method this issue will still remain if someone will do `in: "/usr/i_love_cra%zy_folders"`, but I assumed that it's rather rare usecase and no-one should have % inside folder names.