### PR TITLE
Address all rubocop lint warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ appear at the top.
 
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * Clean up rubocop lint warnings
+    [PR #275](https://github.com/capistrano/sshkit/pull/275)
+    @cshaffer
+    * Prepend unused parameter names with an underscore
+    * Prefer “safe assignment in condition”
+    * Disambiguate regexp literals with parens
+    * Prefer `sprintf` over `String#%`
+    * No longer shadow `caller_line` variable in `DeprecationLogger`
+    * Rescue `StandardError` instead of `Exception`
+    * Remove useless `private` access modifier in `TestAbstract`
+    * Disambiguate block operator with parens
+    * Disambiguate between grouped expression and method params
+    * Remove assertion in `TestHost#test_assert_hosts_compare_equal` that compares something with itself
   * Export environment variables and execute command in a subshell.
     [PR #273](https://github.com/capistrano/sshkit/pull/273)
     @kuon

--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -53,7 +53,7 @@ module SSHKit
         create_command_and_execute(args, options).success?
       end
 
-      def within(directory, &block)
+      def within(directory, &_block)
         (@pwd ||= []).push directory.to_s
         execute <<-EOTEST, verbosity: Logger::DEBUG
           if test ! -d #{File.join(@pwd)}
@@ -66,7 +66,7 @@ module SSHKit
         @pwd.pop
       end
 
-      def with(environment, &block)
+      def with(environment, &_block)
         @_env = (@env ||= {})
         @env = @_env.merge environment
         yield
@@ -75,7 +75,7 @@ module SSHKit
         remove_instance_variable(:@_env)
       end
 
-      def as(who, &block)
+      def as(who, &_block)
         if who.is_a? Hash
           @user  = who[:user]  || who["user"]
           @group = who[:group] || who["group"]
@@ -106,9 +106,9 @@ module SSHKit
       end
 
       # Backends which extend the Abstract backend should implement the following methods:
-      def upload!(local, remote, options = {}) raise MethodUnavailableError end
-      def download!(remote, local=nil, options = {}) raise MethodUnavailableError end
-      def execute_command(cmd) raise MethodUnavailableError end
+      def upload!(_local, _remote, _options = {}) raise MethodUnavailableError end
+      def download!(_remote, _local=nil, _options = {}) raise MethodUnavailableError end
+      def execute_command(_cmd) raise MethodUnavailableError end
       private :execute_command # Can inline after Ruby 2.1
 
       private

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -39,7 +39,7 @@ module SSHKit
       def find_live_entry(key)
         @mutex.synchronize do
           return nil unless @pool.key?(key)
-          while entry = @pool[key].shift
+          while (entry = @pool[key].shift)
             return entry if entry.live?
           end
         end

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -11,7 +11,7 @@ module SSHKit
         @block = block
       end
 
-      def upload!(local, remote, options = {})
+      def upload!(local, remote, _options = {})
         if local.is_a?(String)
           FileUtils.cp(local, remote)
         else
@@ -21,7 +21,7 @@ module SSHKit
         end
       end
 
-      def download!(remote, local=nil, options = {})
+      def download!(remote, local=nil, _options = {})
         if local.nil?
           FileUtils.cp(remote, File.basename(remote))
         else
@@ -40,14 +40,14 @@ module SSHKit
 
         Open3.popen3(cmd.to_command) do |stdin, stdout, stderr, wait_thr|
           stdout_thread = Thread.new do
-            while line = stdout.gets do
+            while (line = stdout.gets) do
               cmd.on_stdout(stdin, line)
               output.log_command_data(cmd, :stdout, line)
             end
           end
 
           stderr_thread = Thread.new do
-            while line = stderr.gets do
+            while (line = stderr.gets) do
               cmd.on_stderr(stdin, line)
               output.log_command_data(cmd, :stderr, line)
             end

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -61,7 +61,7 @@ module SSHKit
       def transfer_summarizer(action)
         last_name = nil
         last_percentage = nil
-        proc do |ch, name, transferred, total|
+        proc do |_ch, name, transferred, total|
           percentage = (transferred.to_f * 100 / total.to_f)
           unless percentage.nan?
             message = "#{action} #{name} #{percentage.round(2)}%"
@@ -87,16 +87,16 @@ module SSHKit
         with_ssh do |ssh|
           ssh.open_channel do |chan|
             chan.request_pty if Netssh.config.pty
-            chan.exec cmd.to_command do |ch, success|
+            chan.exec cmd.to_command do |_ch, _success|
               chan.on_data do |ch, data|
                 cmd.on_stdout(ch, data)
                 output.log_command_data(cmd, :stdout, data)
               end
-              chan.on_extended_data do |ch, type, data|
+              chan.on_extended_data do |ch, _type, data|
                 cmd.on_stderr(ch, data)
                 output.log_command_data(cmd, :stderr, data)
               end
-              chan.on_request("exit-status") do |ch, data|
+              chan.on_request("exit-status") do |_ch, data|
                 exit_status = data.read_long
               end
               #chan.on_request("exit-signal") do |ch, data|
@@ -106,14 +106,14 @@ module SSHKit
               #  warn ">>> " + exit_signal.inspect
               #  output.log_command_killed(cmd, exit_signal)
               #end
-              chan.on_open_failed do |ch|
+              chan.on_open_failed do |_ch|
                 # TODO: What do do here?
                 # I think we should raise something
               end
-              chan.on_process do |ch|
+              chan.on_process do |_ch|
                 # TODO: I don't know if this is useful
               end
-              chan.on_eof do |ch|
+              chan.on_eof do |_ch|
                 # TODO: chan sends EOF before the exit status has been
                 # writtend
               end

--- a/lib/sshkit/backends/skipper.rb
+++ b/lib/sshkit/backends/skipper.rb
@@ -14,7 +14,7 @@ module SSHKit
       alias :download! :execute
       alias :test :execute
 
-      def info(messages)
+      def info(_messages)
         # suppress all messages except `warn`
       end
       alias :log :info

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -130,7 +130,7 @@ module SSHKit
     end
 
     def verbosity
-      if vb = options[:verbosity]
+      if (vb = options[:verbosity])
         case vb.class.name
         when 'Symbol' then return Logger.const_get(vb.to_s.upcase)
         when 'Fixnum' then return vb
@@ -141,12 +141,12 @@ module SSHKit
     end
 
     def should_map?
-      !command.match /\s/
+      !command.match(/\s/)
     end
 
-    def within(&block)
+    def within(&_block)
       return yield unless options[:in]
-      "cd #{options[:in]} && %s" % yield
+      sprintf("cd #{options[:in]} && %s", yield)
     end
 
     def environment_hash
@@ -161,27 +161,27 @@ module SSHKit
       end.join(' ')
     end
 
-    def with(&block)
+    def with(&_block)
       return yield unless environment_hash.any?
-      "( export #{environment_string} ; %s )" % yield
+      sprintf("( export #{environment_string} ; %s )", yield)
     end
 
-    def user(&block)
+    def user(&_block)
       return yield unless options[:user]
       "sudo -u #{options[:user]} #{environment_string + " " unless environment_string.empty?}-- sh -c '%s'" % %Q{#{yield}}
     end
 
-    def in_background(&block)
+    def in_background(&_block)
       return yield unless options[:run_in_background]
-      "( nohup %s > /dev/null & )" % yield
+      sprintf("( nohup %s > /dev/null & )", yield)
     end
 
-    def umask(&block)
+    def umask(&_block)
       return yield unless SSHKit.config.umask
-      "umask #{SSHKit.config.umask} && %s" % yield
+      sprintf("umask #{SSHKit.config.umask} && %s", yield)
     end
 
-    def group(&block)
+    def group(&_block)
       return yield unless options[:group]
       "sg #{options[:group]} -c \\\"%s\\\"" % %Q{#{yield}}
       # We could also use the so-called heredoc format perhaps:

--- a/lib/sshkit/deprecation_logger.rb
+++ b/lib/sshkit/deprecation_logger.rb
@@ -8,7 +8,7 @@ module SSHKit
     def log(message)
       return if @out.nil?
       warning_msg = "[Deprecated] #{message}\n"
-      caller_line = caller.find { |caller_line| !caller_line.include?('lib/sshkit') }
+      caller_line = caller.find { |line| !line.include?('lib/sshkit') }
       warning_msg << "    (Called from #{caller_line})\n" unless caller_line.nil?
       @out << warning_msg unless @previous_warnings.include?(warning_msg)
       @previous_warnings << warning_msg

--- a/lib/sshkit/formatters/abstract.rb
+++ b/lib/sshkit/formatters/abstract.rb
@@ -27,7 +27,7 @@ module SSHKit
         write(command)
       end
 
-      def log_command_data(command, stream_type, stream_data)
+      def log_command_data(command, _stream_type, _stream_data)
         write(command)
       end
 
@@ -39,7 +39,7 @@ module SSHKit
         write(obj)
       end
 
-      def write(obj)
+      def write(_obj)
         raise "Abstract formatter should not be used directly, maybe you want SSHKit::Formatter::BlackHole"
       end
 

--- a/lib/sshkit/formatters/black_hole.rb
+++ b/lib/sshkit/formatters/black_hole.rb
@@ -4,7 +4,7 @@ module SSHKit
 
     class BlackHole < Abstract
 
-      def write(obj)
+      def write(_obj)
         # Nothing, nothing to do
       end
 

--- a/lib/sshkit/formatters/dot.rb
+++ b/lib/sshkit/formatters/dot.rb
@@ -8,7 +8,7 @@ module SSHKit
         original_output << colorize('.', command.failure? ? :red : :green)
       end
 
-      def write(obj)
+      def write(_obj)
       end
 
     end

--- a/lib/sshkit/formatters/simple_text.rb
+++ b/lib/sshkit/formatters/simple_text.rb
@@ -5,11 +5,11 @@ module SSHKit
     class SimpleText < Pretty
 
       # Historically, SimpleText formatter was used to disable coloring, so we maintain that behaviour
-      def colorize(obj, color, mode=nil)
+      def colorize(obj, _color, _mode=nil)
         obj.to_s
       end
 
-      def format_message(verbosity, message, uuid=nil)
+      def format_message(_verbosity, message, _uuid=nil)
         message
       end
 

--- a/lib/sshkit/host.rb
+++ b/lib/sshkit/host.rb
@@ -100,7 +100,7 @@ module SSHKit
   class SimpleHostParser
 
     def self.suitable?(host_string)
-      !host_string.match /[:|@]/
+      !host_string.match(/[:|@]/)
     end
 
     def initialize(host_string)
@@ -128,7 +128,7 @@ module SSHKit
   class HostWithPortParser < SimpleHostParser
 
     def self.suitable?(host_string)
-      !host_string.match /[@|\[|\]]/
+      !host_string.match(/[@|\[|\]]/)
     end
 
     def port
@@ -145,7 +145,7 @@ module SSHKit
   # :nodoc:
   class HostWithUsernameAndPortParser < SimpleHostParser
     def self.suitable?(host_string)
-      host_string.match /@.*:\d+/
+      host_string.match(/@.*:\d+/)
     end
     def username
       @host_string.split(/:|@/)[0]
@@ -163,7 +163,7 @@ module SSHKit
   class IPv6HostWithPortParser < SimpleHostParser
 
     def self.suitable?(host_string)
-      host_string.match /[a-fA-F0-9:]+:\d+/
+      host_string.match(/[a-fA-F0-9:]+:\d+/)
     end
 
     def port

--- a/lib/sshkit/mapping_interaction_handler.rb
+++ b/lib/sshkit/mapping_interaction_handler.rb
@@ -17,7 +17,7 @@ module SSHKit
       end
     end
 
-    def on_data(command, stream_name, data, channel)
+    def on_data(_command, stream_name, data, channel)
       log("Looking up response for #{stream_name} message #{data.inspect}")
 
       response_data = @mapping_proc.call(data)

--- a/lib/sshkit/runners/parallel.rb
+++ b/lib/sshkit/runners/parallel.rb
@@ -11,7 +11,7 @@ module SSHKit
           threads << Thread.new(host) do |h|
             begin
               backend(h, &block).run
-            rescue Exception => e
+            rescue StandardError => e
               e2 = ExecuteError.new e
               raise e2, "Exception while executing #{host.user ? "as #{host.user}@" : "on host "}#{host}: #{e.message}"
             end

--- a/lib/sshkit/runners/sequential.rb
+++ b/lib/sshkit/runners/sequential.rb
@@ -19,7 +19,7 @@ module SSHKit
       private
       def run_backend(host, &block)
         backend(host, &block).run
-      rescue Exception => e
+      rescue StandardError => e
         e2 = ExecuteError.new e
         raise e2, "Exception while executing #{host.user ? "as #{host.user}@" : "on host "}#{host}: #{e.message}"
       end

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -44,7 +44,7 @@ module SSHKit
 
       def test_capture
         captured_command_result = nil
-        Netssh.new(a_host) do |host|
+        Netssh.new(a_host) do |_host|
           captured_command_result = capture(:uname)
         end.run
 
@@ -64,7 +64,7 @@ module SSHKit
 
       def test_env_vars_substituion_in_subshell
         captured_command_result = nil
-        Netssh.new(a_host) do |host|
+        Netssh.new(a_host) do |_host|
           with some_env_var: :some_value do
            captured_command_result = capture(:echo, '$SOME_ENV_VAR')
           end
@@ -74,7 +74,7 @@ module SSHKit
 
       def test_execute_raises_on_non_zero_exit_status_and_captures_stdout_and_stderr
         err = assert_raises SSHKit::Command::Failed do
-          Netssh.new(a_host) do |host|
+          Netssh.new(a_host) do |_host|
             execute :echo, "'Test capturing stderr' 1>&2; false"
           end.run
         end
@@ -82,7 +82,7 @@ module SSHKit
       end
 
       def test_test_does_not_raise_on_non_zero_exit_status
-        Netssh.new(a_host) do |host|
+        Netssh.new(a_host) do |_host|
           test :false
         end.run
       end
@@ -102,7 +102,7 @@ module SSHKit
 
       def test_upload_string_io
         file_contents = ""
-        Netssh.new(a_host) do |host|
+        Netssh.new(a_host) do |_host|
           file_name = File.join("/tmp", SecureRandom.uuid)
           upload!(StringIO.new('example_io'), file_name)
           file_contents = download!(file_name)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -40,7 +40,7 @@ class FunctionalTest < MiniTest::Unit::TestCase
   def create_user_with_key(username, password = :secret)
     username, password = username.to_s, password.to_s
 
-    keys = VagrantWrapper.hosts.collect do |name, host|
+    keys = VagrantWrapper.hosts.collect do |_name, host|
       Net::SSH.start(host.hostname, host.user, port: host.port, password: host.password) do |ssh|
 
         # Remove the user, make it again, force-generate a key for him
@@ -70,7 +70,7 @@ class FunctionalTest < MiniTest::Unit::TestCase
       end
     end
 
-    Hash[VagrantWrapper.hosts.collect { |n, h| n.to_sym }.zip(keys)]
+    Hash[VagrantWrapper.hosts.collect { |n, _h| n.to_sym }.zip(keys)]
   end
 
 end

--- a/test/unit/backends/test_abstract.rb
+++ b/test/unit/backends/test_abstract.rb
@@ -117,8 +117,6 @@ module SSHKit
         end
       end
 
-      private
-
       # Use a concrete ExampleBackend rather than a mock for improved assertion granularity
       class ExampleBackend < Abstract
         attr_writer :full_stdout

--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -15,11 +15,11 @@ module SSHKit
       end
 
       def connect
-        ->(*args) { Object.new }
+        ->(*_args) { Object.new }
       end
 
       def connect_and_close
-        ->(*args) { OpenStruct.new(:closed? => true) }
+        ->(*_args) { OpenStruct.new(:closed? => true) }
       end
 
       def echo_args

--- a/test/unit/test_coordinator.rb
+++ b/test/unit/test_coordinator.rb
@@ -14,7 +14,7 @@ module SSHKit
     end
 
     def echo_time
-      lambda do |host|
+      lambda do |_host|
         execute "echo #{Time.now.to_f}"
       end
     end
@@ -45,7 +45,7 @@ module SSHKit
     end
 
     def test_the_connection_manaager_runs_things_in_parallel_by_default
-      Coordinator.new(%w{1.example.com 2.example.com}).each &echo_time
+      Coordinator.new(%w{1.example.com 2.example.com}).each(&echo_time)
       assert_equal 2, actual_execution_times.length
       assert_within_10_ms(actual_execution_times)
     end
@@ -60,7 +60,7 @@ module SSHKit
       start = Time.now
       Coordinator.new(%w{1.example.com 2.example.com}).each in: :sequence, wait: 10, &echo_time
       stop = Time.now
-      assert_operator (stop - start), :>=, 10.0
+      assert_operator(stop - start, :>=, 10.0)
     end
 
     def test_the_connection_manager_can_run_things_in_groups
@@ -85,11 +85,11 @@ module SSHKit
     private
 
     def assert_at_least_1_sec_apart(first_time, last_time)
-      assert_operator (last_time - first_time), :>, 1.0
+      assert_operator(last_time - first_time, :>, 1.0)
     end
 
     def assert_within_10_ms(array)
-      assert_in_delta *array, 0.01 # 10 msec
+      assert_in_delta(*array, 0.01) # 10 msec
     end
 
     def actual_execution_times

--- a/test/unit/test_host.rb
+++ b/test/unit/test_host.rb
@@ -65,7 +65,6 @@ module SSHKit
     end
 
     def test_assert_hosts_compare_equal
-      assert Host.new('example.com') == Host.new('example.com')
       assert Host.new('example.com').eql? Host.new('example.com')
       assert Host.new('example.com').equal? Host.new('example.com')
     end


### PR DESCRIPTION
* Prepend unused parameter names with an underscore
* Prefer “safe assignment in condition”
* Disambiguate regexp literals with parens
* Prefer `sprintf` over `String#%`
* No longer shadow `caller_line` variable in `DeprecationLogger`
* Rescue `StandardError` instead of `Exception`
* Remove useless `private` access modifier in `TestAbstract`
* Disambiguate block operator with parens
* Disambiguate between grouped expression and method params
* Remove assertion in `TestHost#test_assert_hosts_compare_equal` that compares something with itself