### PR TITLE
Use string interpolation for environment variables to avoid escaping issues with sprintf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ appear at the top.
 
 ## [Unreleased][]
 
-  * Escape '%' in environment string before it is passed to sprintf.
-    [PR #280](https://github.com/capistrano/sshkit/pull/280)
-    @Sinjo - Chris Sinjakli
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * Use string interpolation for environment variables to avoid escaping issues
+    with sprintf
+    [PR #280](https://github.com/capistrano/sshkit/pull/280)
+    @Sinjo - Chris Sinjakli
 
 ## [1.11.3][] (2016-09-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ appear at the top.
 
 ## [Unreleased][]
 
+  * Escape '%' in environment string before it is passed to sprintf.
+    [PR #280](https://github.com/capistrano/sshkit/pull/280)
+    @Sinjo - Chris Sinjakli
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
 

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -161,18 +161,14 @@ module SSHKit
       end.join(' ')
     end
 
-    def sprintf_escaped_environment_string
-      environment_string.gsub('%', '%%')
-    end
-
     def with(&_block)
       return yield unless environment_hash.any?
-      sprintf("( export #{sprintf_escaped_environment_string} ; %s )", yield)
+      "( export #{environment_string} ; #{yield} )"
     end
 
     def user(&_block)
       return yield unless options[:user]
-      "sudo -u #{options[:user]} #{sprintf_escaped_environment_string + " " unless sprintf_escaped_environment_string.empty?}-- sh -c '%s'" % %Q{#{yield}}
+      "sudo -u #{options[:user]} #{environment_string + " " unless environment_string.empty?}-- sh -c '#{yield}'"
     end
 
     def in_background(&_block)

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -161,14 +161,18 @@ module SSHKit
       end.join(' ')
     end
 
+    def sprintf_escaped_environment_string
+      environment_string.gsub('%', '%%')
+    end
+
     def with(&_block)
       return yield unless environment_hash.any?
-      sprintf("( export #{environment_string} ; %s )", yield)
+      sprintf("( export #{sprintf_escaped_environment_string} ; %s )", yield)
     end
 
     def user(&_block)
       return yield unless options[:user]
-      "sudo -u #{options[:user]} #{environment_string + " " unless environment_string.empty?}-- sh -c '%s'" % %Q{#{yield}}
+      "sudo -u #{options[:user]} #{sprintf_escaped_environment_string + " " unless sprintf_escaped_environment_string.empty?}-- sh -c '%s'" % %Q{#{yield}}
     end
 
     def in_background(&_block)

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -49,7 +49,7 @@ module SSHKit
       assert_equal %{( export FOO="asdf\\\"hjkl" ; /usr/bin/env rails server )}, c.to_command
     end
 
-    def test_percentage_symbol_escaped_before_sprintf
+    def test_percentage_symbol_handled_in_env
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {foo: 'asdf%hjkl'}, user: "anotheruser")
       assert_equal %{( export FOO="asdf%hjkl" ; sudo -u anotheruser FOO=\"asdf%hjkl\" -- sh -c '/usr/bin/env rails server' )}, c.to_command

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -49,6 +49,12 @@ module SSHKit
       assert_equal %{( export FOO="asdf\\\"hjkl" ; /usr/bin/env rails server )}, c.to_command
     end
 
+    def test_percentage_symbol_escaped_before_sprintf
+      SSHKit.config = nil
+      c = Command.new(:rails, 'server', env: {foo: 'asdf%hjkl'}, user: "anotheruser")
+      assert_equal %{( export FOO="asdf%hjkl" ; sudo -u anotheruser FOO=\"asdf%hjkl\" -- sh -c '/usr/bin/env rails server' )}, c.to_command
+    end
+
     def test_including_the_env_doesnt_addressively_escape
       SSHKit.config = nil
       c = Command.new(:rails, 'server', env: {path: '/example:$PATH'})


### PR DESCRIPTION
@leehambley Following on from the discussion in #264.

`user` also runs the environment variables through `sprintf`, so I've applied the same fix there.