### PR TITLE
add `:before` option to run `source ~/.bashrc`

### DIFF
--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -75,6 +75,10 @@ module SSHKit
         remove_instance_variable(:@_env)
       end
 
+      def prerun(command, &_block)
+        (@before ||= []).push command.to_s
+      end
+
       def as(who, &_block)
         if who.is_a? Hash
           @user  = who[:user]  || who["user"]
@@ -122,7 +126,7 @@ module SSHKit
       end
 
       def command(args, options)
-        SSHKit::Command.new(*[*args, options.merge({in: @pwd.nil? ? nil : File.join(@pwd), env: @env, host: @host, user: @user, group: @group})])
+        SSHKit::Command.new(*[*args, options.merge({in: @pwd.nil? ? nil : File.join(@pwd), env: @env, host: @host, user: @user, group: @group, before: @before})])
       end
 
     end

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -188,6 +188,14 @@ module SSHKit
       #"newgrp #{options[:group]} <<EOC \\\"%s\\\" EOC" % %Q{#{yield}}
     end
 
+    def before
+      return yield unless options[:before]
+      before_string = Array === options[:before] ?
+        options[:before].join(" ; ") :
+        options[:before].to_s
+      "#{before_string} ; #{yield}"
+    end
+
     def to_command
       return command.to_s unless should_map?
       within do
@@ -196,7 +204,9 @@ module SSHKit
             user do
               in_background do
                 group do
-                  to_s
+                  before do
+                    to_s
+                  end
                 end
               end
             end

--- a/test/unit/backends/test_abstract.rb
+++ b/test/unit/backends/test_abstract.rb
@@ -35,7 +35,7 @@ module SSHKit
 
         assert_equal '/usr/bin/env ls -l /some/directory', backend.executed_command.to_command
         assert_equal(
-          {:raise_on_non_zero_exit=>true, :run_in_background=>false, :in=>nil, :env=>nil, :host=>ExampleBackend.example_host, :user=>nil, :group=>nil},
+          {:raise_on_non_zero_exit=>true, :run_in_background=>false, :in=>nil, :env=>nil, :host=>ExampleBackend.example_host, :user=>nil, :group=>nil, :before=>nil},
           backend.executed_command.options
         )
       end


### PR DESCRIPTION
# About

This pull request adds `:before` option on `Command`, which let us run other preparation command beforehand.
Typical usage is to run `source ~/.bashrc` before running a command.

# Problem

When I run Capistrano, I always run into the environment variable problem. I just want to read `~/.bashrc` to set my `$PATH`, but I have to set it in my `config/deploy.rb`.

Adding environments variable is not always a good way. Situations I have experienced is:

  - Ruby is installed via `rbenv`, which means I can't run `bundle exec rake` unless I read `~/.bash_profile`
  - Environment variables includes confidential information, so they should only be in the production servers, not in deployment codes or in deploy server

# Usage

Example from the test:

```
irb(main):001:0> puts Command.new(:touch, 'somefile', user: 'bob', env: {a: 'b'}, in: '/var', before: 'source ~/.bashrc').to_command
cd /var && umask 007 && ( export A="b" ; sudo -u bob A="b" -- sh -c 'source ~/.bashrc ; /usr/bin/env touch somefile'
```