### PR TITLE
add SSHKit::Backend::ConnectionPool#close_connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ appear at the top.
 
 ## `master` (Unreleased)
 
+  * add SSHKit::Backend::ConnectionPool#close_connections
+    [PR #285](https://github.com/capistrano/sshkit/pull/285)
+    @akm
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
   * Clean up rubocop lint warnings

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -33,7 +33,6 @@ module SSHKit
       def close_connections
         @mutex.synchronize do
           @pool.values.flatten.map(&:connection).uniq.each do |conn|
-            $stdout.puts conn.inspect
             if conn.respond_to?(:closed?) && conn.respond_to?(:close)
               conn.close unless conn.closed?
             end

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -30,6 +30,18 @@ module SSHKit
         end
       end
 
+      def close_connections
+        @mutex.synchronize do
+          @pool.values.flatten.map(&:connection).uniq.each do |conn|
+            $stdout.puts conn.inspect
+            if conn.respond_to?(:closed?) && conn.respond_to?(:close)
+              conn.close unless conn.closed?
+            end
+          end
+          @pool.clear
+        end
+      end
+
       def flush_connections
         @mutex.synchronize { @pool.clear }
       end

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SSHKit::VERSION
 
-  gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
+  gem.add_runtime_dependency('net-ssh',  '>= 2.8.0', '< 3.0.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')
 
   gem.add_development_dependency('minitest', ['>= 2.11.3', '< 2.12.0'])

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SSHKit::VERSION
 
-  gem.add_runtime_dependency('net-ssh',  '~> 2.8')
+  gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')
 
   gem.add_development_dependency('minitest', ['>= 2.11.3', '< 2.12.0'])

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SSHKit::VERSION
 
-  gem.add_runtime_dependency('net-ssh',  '>= 2.8.0', '< 3.0.0')
+  gem.add_runtime_dependency('net-ssh',  '~> 2.8')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')
 
   gem.add_development_dependency('minitest', ['>= 2.11.3', '< 2.12.0'])

--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -111,6 +111,18 @@ module SSHKit
         refute_equal conn1, conn2
       end
 
+      def test_close_connections
+        conn1 = mock
+        conn1.expects(:closed?).returns(false)
+        conn1.expects(:close)
+        entry1 = pool.checkout("conn1"){|*args| conn1 }
+        pool.checkin entry1
+        entry2 = pool.checkout("conn2", &connect)
+        # entry2 isn't closed if close_connections is called
+
+        pool.close_connections
+      end
+
     end
   end
 end


### PR DESCRIPTION
If sshkit is used not in capistrano but in a daemon, SSH connections are kept in CollectionPool. But there is  no method to close them explicitly, so I added SSHKit::Backend::ConnectionPool#close_connections method to close them.

Suppressed net-ssh version `< 3.0.0` to prevent installing error on ruby 1.9.2 and 1.9.3.
- https://travis-ci.org/capistrano/sshkit/jobs/82688897
- https://travis-ci.org/capistrano/sshkit/jobs/82688898
