### PR TITLE
Monkey patch net-ssh to make hashing scheme work

### DIFF
--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -1,5 +1,19 @@
 require "thread"
 
+# Since we call to_s on new_connection_args and use that as a hash
+# We need to make sure the memory address of the object is not used as part of the key
+# Otherwise identical objects with different memory address won't get a hash hit.
+# In the case of proxy commands, this can lead to proxy processes leaking
+# And in severe cases can cause deploys to fail due to default file descriptor limits
+# An alternate solution would be to use a different means of generating hash keys
+module Net; module SSH; module Proxy
+  class Command
+    def inspect
+      @command_line_template
+    end
+  end
+end;end;end
+
 module SSHKit
 
   module Backend


### PR DESCRIPTION
@leehambley @mattbrictson for review

[this line](https://github.com/capistrano/sshkit/blob/master/lib/sshkit/backends/connection_pool.rb#L19) causes sshkit to call inspect on "new_connection_args" and stringify it. This causes the **memory address** of the proxy object to be included in the hash key, meaning that identical objects that just have a different address won't get a hash hit. This causes it to generate new connections over and over and over as it will never find the connection it's looking for, so it just generates new ones and shoves them in the hash.

For instance:

This key:
```
["SOME_HOST", "deploy", {:user=>"deploy", :forward_agent=>true, :proxy=>#<Net::SSH::Proxy::Command:0x00000000b8c9a0 @command_line_template="ssh deploy@SOME_BASTION nc %h %p", @command_line=nil>}]
```

Doesn't match this key:
```
["SOME_HOST", "deploy", {:user=>"deploy", :forward_agent=>true, :proxy=>#<Net::SSH::Proxy::Command:0x000000010010a8 @command_line_template="ssh deploy@SOME_BASTION nc %h %p", @command_line=nil>}]
```

Because the memory address is different, even though this connection could totally be reused, so the code bails out of find_live_entry https://github.com/capistrano/sshkit/blob/master/lib/sshkit/backends/connection_pool.rb#L41

The patch here is actually to support 'inspect' in sshkit, and use the command line template, which is all way care about. This will cause the hashes to properly hit again, and stops the run away connections.

In our case, we have 2 gateways we need to proxy through - one for each region in amazon that our app lives in. For this reason, we specify the proxy **on each host** so that the use the correct proxy (the one in their region). This causes the code to render a new proxy command object for each host, on each command.

In our case, with just 12 hosts in each region, essentially every command would need a new connection. This caused an SSH command to run for each capistrano command, and these commands would never be reaped. The pipe used by each command, along with the shared objects, caused the file descriptors used by capistrano and it's children to easily blow past the default of 1024. Not to mention substantially slowing down the deploy.

Under this scheme, we can again just have a single proxy for each host which is a much more manageable number of proxies.

**This is definitely not a pretty solution**, I would prefer just generating the key in a different way, but this is the most elegant thing I could think of given the current structure.

I would happily use a different hashing scheme, so long as it's consistent and based on the object attributes, and not the object addresses.

Solves the issue i had with proxy command leaking processes and FDs mentioned in https://github.com/capistrano/capistrano/issues/725