### PR TITLE
Add chandler to `rake release`; improve docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,10 @@ platforms :rbx do
   gem 'rubysl', '~> 2.0'
   gem 'json'
 end
+
+# Chandler requires Ruby >= 2.1.0, but depending on the Travis environment,
+# we may not meet that requirement. Only include the chandler gem if the Ruby
+# requirement is met. (Chandler is used only for `rake release`; see Rakefile.)
+if Gem::Requirement.new('>= 2.1.0').satisfied_by?(Gem::Version.new(RUBY_VERSION))
+  gem 'chandler', '>= 0.1.1'
+end

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,10 +1,18 @@
 # Releasing
 
-* **Ensure the tests are passing.**
-* Determine which would be the correct next version number according to [semver](http://semver.org/).
-* Update the version in `./lib/sshkit/version.rb`.
-* Update the `CHANGELOG`.
-* Commit the changelog and version in a single commit, the message should be "Preparing vX.Y.Z"
-* Tag the commit `git tag vX.Y.Z` (if tagging a historical commit, `git tag` can take a *SHA1* after the tag name)
-* Push new commits, and tags to Github.
-* Push the gem to [rubygems](http://rubygems.org).
+## Prerequisites
+
+* You must have commit rights to the SSHKit repository.
+* You must have push rights for the sshkit gem on rubygems.org.
+* You must be using Ruby >= 2.1.0.
+* Your `~/.netrc` must be configured with your GitHub credentials, [as explained here](https://github.com/mattbrictson/chandler#2-configure-netrc).
+
+## How to release
+
+1. Run `bundle install` to make sure that you have all the gems necessary for testing and releasing.
+2.  **Ensure the tests are passing by running `rake test`.** If functional tests fail, ensure you have [Vagrant](https://www.vagrantup.com) installed and have started it with `vagrant up`.
+3. Determine which would be the correct next version number according to [semver](http://semver.org/).
+4. Update the version in `./lib/sshkit/version.rb`.
+5. Update the `CHANGELOG`.
+6. Commit the changelog and version in a single commit, the message should be "Preparing vX.Y.Z"
+7. Run `rake release`; this will tag, push to GitHub, publish to rubygems.org, and upload the latest changelog entry to the [GitHub releases page](https://github.com/capistrano/sshkit/releases).

--- a/Rakefile
+++ b/Rakefile
@@ -25,3 +25,11 @@ end
 Rake::Task["test:functional"].enhance do
   warn "Remember there are still some VMs running, kill them with `vagrant halt` if you are finished using them."
 end
+
+task "release:rubygem_push" do
+  # Delay loading Chandler until this point, since it requires Ruby >= 2.1,
+  # which may not be available in all environments (e.g. Travis).
+  # We assume that the person doing `rake release` has Ruby >= 2.1.
+  require "chandler/tasks"
+  Rake.application.invoke_task("chandler:push")
+end


### PR DESCRIPTION
Chandler is a small gem that plugs into Bundler's `rake release` rake task. Upon successful release to rubygems.org, Chandler will parse the SSHKit CHANGELOG and upload the release notes it finds there to the Releases page on GitHub.

This ensures that the GitHub releases page always has our latest release notes, without requiring tedious copy and paste.

As an example, if you look at the [Releases](https://github.com/capistrano/sshkit/releases) page now, you can see the 1.7.1 release notes. These were parsed from the existing CHANGELOG and uploaded by running `chandler push v1.7.1`. This PR makes this process automatic by doing a `chandler push` whenever we `rake release`.

I made changes to the `RELEASING.md` to explain the prerequisites for using `rake release`. Notably, chandler requires GitHub API access, which means you need to configure GitHub in `~/.netrc`.

Note that since Chandler requires Ruby 2.1+, and SSHKit supports back to 2.0, I've added some conditional logic in the Gemfile and Rakefile to ensure the build does not blow up in a Ruby 2.0 environment.