### PR TITLE
Use env vars instead of Etc module for local user lookup

### DIFF
--- a/lib/sshkit/host.rb
+++ b/lib/sshkit/host.rb
@@ -1,5 +1,4 @@
 require 'ostruct'
-require 'etc'
 
 module SSHKit
 
@@ -26,7 +25,7 @@ module SSHKit
       if host_string_or_options_hash == :local
         @local = true
         @hostname = "localhost"
-        @user = Etc.getpwuid.name
+        @user = ENV['USER'] || ENV['LOGNAME'] || ENV['USERNAME']
       elsif !host_string_or_options_hash.is_a?(Hash)
         suitable_parsers = [
           SimpleHostParser,

--- a/test/unit/test_host.rb
+++ b/test/unit/test_host.rb
@@ -1,5 +1,4 @@
 require 'helper'
-require 'etc'
 
 module SSHKit
 
@@ -46,8 +45,9 @@ module SSHKit
       h = Host.new :local
       assert       h.local?
       assert_nil   h.port
-      assert_equal Etc.getpwuid.name, h.username
-      assert_equal 'localhost',       h.hostname
+      username_candidates = ENV['USER'] || ENV['LOGNAME'] || ENV['USERNAME']
+      assert_equal username_candidates, h.username
+      assert_equal 'localhost',         h.hostname
     end
 
     def test_does_not_confuse_ipv6_hosts_with_port_specification


### PR DESCRIPTION
This ensures that the code works on both Unix and Windows, while `Etc.getpwuid` relied on /etc/passwd being present, so it returned a NoMethodError when calling `name` on Windows.

This change has been discussed in capistrano/capistrano#1521.