### PR TITLE
New API for setting+configuring formatter: use_format

### DIFF
--- a/lib/sshkit/configuration.rb
+++ b/lib/sshkit/configuration.rb
@@ -53,9 +53,16 @@ module SSHKit
     end
 
     def formatter(format)
-      SSHKit::Formatter.constants.each do |const|
-        return SSHKit::Formatter.const_get(const).new($stdout) if const.downcase.eql?(format.downcase)
+      formatter_class(format).new($stdout)
+    end
+
+    def formatter_class(symbol)
+      name = symbol.to_s.downcase
+      found = SSHKit::Formatter.constants.find do |const|
+        const.to_s.downcase == name
       end
+      fail NameError, 'Unrecognized SSHKit::Formatter "#{symbol}"' if found.nil?
+      SSHKit::Formatter.const_get(found)
     end
 
   end

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -78,6 +78,11 @@ module SSHKit
       end
     end
 
+    def test_prohibits_unknown_formatter_type_with_exception
+      assert_raises(NameError) do
+        SSHKit.config.format = :doesnotexist
+      end
+    end
   end
 
 end

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -83,6 +83,23 @@ module SSHKit
         SSHKit.config.format = :doesnotexist
       end
     end
+
+    def test_options_can_be_provided_to_formatter
+      SSHKit.config.use_format(TestFormatter, :color => false)
+      formatter = SSHKit.config.output
+      assert_instance_of(TestFormatter, formatter)
+      assert_equal($stdout, formatter.output)
+      assert_equal({ :color => false }, formatter.options)
+    end
+
+    class TestFormatter
+      attr_accessor :output, :options
+
+      def initialize(output, options={})
+        @output = output
+        @options = options
+      end
+    end
   end
 
 end


### PR DESCRIPTION
As discussed in https://github.com/mattbrictson/airbrussh/pull/64#issuecomment-152255622, this PR adds a new API for setting the SSHKit output.

Before:

```ruby
SSHKit.config.format = :pretty
```

After:

```ruby
SSHKit.config.use_format :pretty
```

The benefit is that the new `use_format` accepts arbitrary arguments that are then passed to the formatter's constructor. This allows a formatter to be configured.

Hypothetical example:

```ruby
SSHKit.config.use_format :airbrussh, :color => true, :truncate => false
```

This would construct `SSHKit::Formatter::Airbrussh` and pass `{ :color => true, :truncate => false }` to its constructor.

SSHKit's current formatters do not yet accept extra arguments, but this API lays the groundwork for future formatters or formatter gems like airbrussh that are configurable and would benefit from a standard API for doing so.

Eventually we could deprecate the `format=` API, but that can be a separate PR.

@leehambley, @robd Let me know if this looks good and I'll expand this PR to a CHANGELOG entry and update the docs.

Also: this PR fixes a bug where calling `format = :bad_value` proceeds with no error or warning, but blows up later once a logging operation is attempted. Now it will immediately raise `NameError`.