### PR TITLE
New API for setting+configuring formatter: use_format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ appear at the top.
     * Removed `Printer` from backend hierarchy for `Local` and `Netssh` backends (they now just extend `Abstract`)
     * Removed unused `Net::SSH:LogLevelShim`
   * Removed dependency on the `colorize` gem. SSHKit now implements its own ANSI color logic, with no external dependencies. Note that SSHKit now only supports the `:bold` or plain modes. Other modes will be gracefully ignored. [#263](https://github.com/capistrano/sshkit/issues/263)
+  * New API for setting the formatter: `use_format`. This differs from `format=` in that it accepts options or arguments that will be passed to the formatter's constructor. The `format=` syntax will be deprecated in a future release. [#295](https://github.com/capistrano/sshkit/issues/295)
+  * SSHKit now immediately raises a `NameError` if you try to set a formatter that does not exist. [#295](https://github.com/capistrano/sshkit/issues/295)
 
 ## 1.7.1
 

--- a/README.md
+++ b/README.md
@@ -402,25 +402,12 @@ See the `SSHKit::MappingInteractionHandler` for an example of this.
 By default, the output format is set to `:pretty`:
 
 ```ruby
-SSHKit.config.format = :pretty
+SSHKit.config.use_format :pretty
 ```
 
 However, if you prefer non colored text you can use the `:simpletext` formatter. If you want minimal output,
 there is also a `:dot` formatter which will simply output red or green dots based on the success or failure of commands.
 There is also a `:blackhole` formatter which does not output anything.
-
-By default, formatters log to `$stdout`, but they can be constructed with any object which implements `<<`
-for example any `IO` subclass, `String`, `Logger` etc:
-
-```ruby
-# Output to a String:
-output = String.new
-SSHKit.config.output = SSHKit::Formatter::Pretty.new(output)
-# Do something with output
-
-# Or output to a file:
-SSHKit.config.output = SSHKit::Formatter::SimpleText.new(File.open('log/deploy.log', 'wb'))
-```
 
 #### Output Colors
 
@@ -446,7 +433,19 @@ Want custom output formatting? Here's what you have to do:
 1. Set the output format as described above. E.g. if your new formatter is called `FooBar`:
 
 ```ruby
-SSHKit.config.format = :foobar
+SSHKit.config.use_format = :foobar
+```
+
+If your formatter class takes a second `options` argument in its constructor, you can pass options to it like this:
+
+```ruby
+SSHKit.config.use_format = :foobar, :my_option => "value"
+```
+
+Which will call your constructor:
+
+```ruby
+SSHKit::Formatter::FooBar.new($stdout, :my_option => "value")
 ```
 
 ## Output Verbosity

--- a/lib/sshkit/configuration.rb
+++ b/lib/sshkit/configuration.rb
@@ -53,9 +53,16 @@ module SSHKit
     end
 
     def formatter(format)
-      SSHKit::Formatter.constants.each do |const|
-        return SSHKit::Formatter.const_get(const).new($stdout) if const.downcase.eql?(format.downcase)
+      formatter_class(format).new($stdout)
+    end
+
+    def formatter_class(symbol)
+      name = symbol.to_s.downcase
+      found = SSHKit::Formatter.constants.find do |const|
+        const.to_s.downcase == name
       end
+      fail NameError, 'Unrecognized SSHKit::Formatter "#{symbol}"' if found.nil?
+      SSHKit::Formatter.const_get(found)
     end
 
   end

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -78,6 +78,11 @@ module SSHKit
       end
     end
 
+    def test_prohibits_unknown_formatter_type_with_exception
+      assert_raises(NameError) do
+        SSHKit.config.format = :doesnotexist
+      end
+    end
   end
 
 end

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -83,6 +83,23 @@ module SSHKit
         SSHKit.config.format = :doesnotexist
       end
     end
+
+    def test_options_can_be_provided_to_formatter
+      SSHKit.config.use_format(TestFormatter, :color => false)
+      formatter = SSHKit.config.output
+      assert_instance_of(TestFormatter, formatter)
+      assert_equal($stdout, formatter.output)
+      assert_equal({ :color => false }, formatter.options)
+    end
+
+    class TestFormatter
+      attr_accessor :output, :options
+
+      def initialize(output, options={})
+        @output = output
+        @options = options
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Redo of #294 to include README and CHANGELOG updates.