### PR TITLE
Reinstate output doc I deleted by mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,19 @@ However, if you prefer non colored text you can use the `:simpletext` formatter.
 there is also a `:dot` formatter which will simply output red or green dots based on the success or failure of commands.
 There is also a `:blackhole` formatter which does not output anything.
 
+By default, formatters log to `$stdout`, but they can be constructed with any object which implements `<<`
+for example any `IO` subclass, `String`, `Logger` etc:
+
+```ruby
+# Output to a String:
+output = String.new
+SSHKit.config.output = SSHKit::Formatter::Pretty.new(output)
+# Do something with output
+
+# Or output to a file:
+SSHKit.config.output = SSHKit::Formatter::SimpleText.new(File.open('log/deploy.log', 'wb'))
+```
+
 #### Output Colors
 
 By default, SSHKit will color the output using ANSI color escape sequences
@@ -433,13 +446,13 @@ Want custom output formatting? Here's what you have to do:
 1. Set the output format as described above. E.g. if your new formatter is called `FooBar`:
 
 ```ruby
-SSHKit.config.use_format = :foobar
+SSHKit.config.use_format :foobar
 ```
 
 If your formatter class takes a second `options` argument in its constructor, you can pass options to it like this:
 
 ```ruby
-SSHKit.config.use_format = :foobar, :my_option => "value"
+SSHKit.config.use_format :foobar, :my_option => "value"
 ```
 
 Which will call your constructor:


### PR DESCRIPTION
Reinstate the doc I accidentally removed in https://github.com/capistrano/sshkit/pull/296#issuecomment-152871755

Good catch, @robd. Sorry about that!