### PR TITLE
Close expired pool connections

### DIFF
--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -95,6 +95,18 @@ module SSHKit
         refute_equal conn1, conn2
       end
 
+      def test_expired_connection_is_closed
+        pool.idle_timeout = 0.1
+        conn1 = mock
+        conn1.expects(:closed?).returns(false)
+        conn1.expects(:close)
+
+        entry1 = pool.checkout("conn1"){|*args| conn1 }
+        pool.checkin entry1
+        sleep(pool.idle_timeout)
+        pool.checkout("conn2"){|*args| Object.new}
+      end
+
       def test_closed_connection_is_not_reused
         conn1 = pool.checkout("conn", &connect_and_close)
         pool.checkin conn1


### PR DESCRIPTION
Ensure expired pool connections are closed.

I encountered this issue using sshkit with a large number of hosts.  My setup relies on jump hosts. `Net::SSH` is correctly parsing the jump host config from my ~/.ssh/config, and is connecting just fine.  However, since sshkit isn't closing the expired connections, I'm accumulating hundreds/thousands of external processes (the result of `ProxyCommand` in my ~/.ssh/config).  Eventually this starves my system of resources and the ruby process dies.

Anyway, this PR ensures expired connections are closed and pruned at checkout and checkin.  Ultimately the pool might make more sense as an LRU cache with an upper bound on number of entries, but that seemed like too much change at once.