### PR TITLE
Formatters::Pretty: display command being run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ appear at the top.
   * make sure working directory for commands is properly cleared after `within` blocks
     [PR #307](https://github.com/capistrano/sshkit/pull/307)
     @steved
+  * display more accurate string for commands with spaces being output in `Formatter::Pretty`
+    [PR #304](https://github.com/capistrano/sshkit/pull/304)
+    @steved
 
 ## 1.8.1
 

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -206,7 +206,11 @@ module SSHKit
     end
 
     def to_s
-      [SSHKit.config.command_map[command.to_sym], *Array(args)].join(' ')
+      if should_map?
+        [SSHKit.config.command_map[command.to_sym], *Array(args)].join(' ')
+      else
+        command.to_s
+      end
     end
 
     private

--- a/test/unit/backends/test_printer.rb
+++ b/test/unit/backends/test_printer.rb
@@ -22,7 +22,7 @@ module SSHKit
       def test_execute
         printer.execute 'uname -a'
         assert_output_lines(
-          '  INFO [aaaaaa] Running /usr/bin/env uname -a on example.com',
+          '  INFO [aaaaaa] Running uname -a on example.com',
           ' DEBUG [aaaaaa] Command: uname -a'
         )
       end
@@ -31,7 +31,7 @@ module SSHKit
         printer.test '[ -d /some/file ]'
 
         assert_output_lines(
-          ' DEBUG [aaaaaa] Running /usr/bin/env [ -d /some/file ] on example.com',
+          ' DEBUG [aaaaaa] Running [ -d /some/file ] on example.com',
           ' DEBUG [aaaaaa] Command: [ -d /some/file ]'
         )
       end
@@ -42,7 +42,7 @@ module SSHKit
         assert_equal '', result
 
         assert_output_lines(
-          ' DEBUG [aaaaaa] Running /usr/bin/env ls -l on example.com',
+          ' DEBUG [aaaaaa] Running ls -l on example.com',
           ' DEBUG [aaaaaa] Command: ls -l'
         )
       end


### PR DESCRIPTION
It seemed odd to see the `/usr/bin/env` prefix when that wasn't the command being run.