### PR TITLE
pwd is an empty array if already instantiated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ appear at the top.
 
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * make sure working directory for commands is properly cleared after `within` blocks
+    [PR #307](https://github.com/capistrano/sshkit/pull/307)
+    @steved
 
 ## 1.8.1
 

--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -121,8 +121,16 @@ module SSHKit
         command(args, options).tap { |cmd| execute_command(cmd) }
       end
 
+      def pwd_path
+        if @pwd.nil? || @pwd.empty?
+          nil
+        else
+          File.join(@pwd)
+        end
+      end
+
       def command(args, options)
-        SSHKit::Command.new(*[*args, options.merge({in: @pwd.nil? ? nil : File.join(@pwd), env: @env, host: @host, user: @user, group: @group})])
+        SSHKit::Command.new(*[*args, options.merge({in: pwd_path, env: @env, host: @host, user: @user, group: @group})])
       end
 
     end

--- a/test/unit/backends/test_abstract.rb
+++ b/test/unit/backends/test_abstract.rb
@@ -77,6 +77,20 @@ module SSHKit
         assert_equal "Some stdout\n     ", output
       end
 
+      def test_within_properly_clears
+        backend = ExampleBackend.new do
+          within 'a' do
+            execute :cat, 'file', :strip => false
+          end
+
+          execute :cat, 'file', :strip => false
+        end
+
+        backend.run
+
+        assert_equal '/usr/bin/env cat file', backend.executed_command.to_command
+      end
+
       def test_background_logs_deprecation_warnings
         deprecation_out = ''
         SSHKit.config.deprecation_output = deprecation_out


### PR DESCRIPTION
This might be what was reported in #265. Once a `within` is called and exited, any other mapped commands will execute in the $HOME directory. Still working on tests.