### PR TITLE
Upgrade to minitest 5

### DIFF
--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')
 
-  gem.add_development_dependency('minitest', ['>= 2.11.3', '< 2.12.0'])
+  gem.add_development_dependency('minitest', '>= 5.0.0')
+  gem.add_development_dependency('minitest-reporters')
   gem.add_development_dependency('rake')
-  gem.add_development_dependency('turn')
   gem.add_development_dependency('unindent')
   gem.add_development_dependency('mocha')
 end

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -3,7 +3,7 @@ module SSHKit
 
   module Backend
 
-    class TestLocal < MiniTest::Unit::TestCase
+    class TestLocal < Minitest::Test
 
       def setup
         super

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,9 +1,9 @@
 require 'rubygems'
 require 'bundler/setup'
 require 'tempfile'
-require 'minitest/unit'
+require 'minitest/autorun'
+require 'minitest/reporters'
 require 'mocha/setup'
-require 'turn'
 require 'unindent'
 require 'stringio'
 require 'json'
@@ -14,7 +14,7 @@ require 'sshkit'
 
 Dir[File.expand_path('test/support/*.rb')].each { |file| require file }
 
-class UnitTest < MiniTest::Unit::TestCase
+class UnitTest < Minitest::Test
 
   def setup
     SSHKit.reset_configuration!
@@ -27,7 +27,7 @@ class UnitTest < MiniTest::Unit::TestCase
   end
 end
 
-class FunctionalTest < MiniTest::Unit::TestCase
+class FunctionalTest < Minitest::Test
 
   def setup
     unless VagrantWrapper.running?
@@ -78,7 +78,4 @@ end
 #
 # Force colours in Autotest
 #
-Turn.config.ansi = true
-Turn.config.format = :pretty
-
-MiniTest::Unit.autorun
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new


### PR DESCRIPTION
SSHKit was using the `turn` gem, which is no longer maintained. SSHKit was also pinned to a very old version of the minitest gem (released in 2012).

This commit brings SSHKit up to the current 5.x version of minitest, and replaces the turn gem with minitest-reporters, which provides similar rspec-like output with ansi color.

Other changes in minitest 5:

* `MiniTest::Unit::TestCase` is now `Minitest::Test`
* `require 'minitest/autorun'` instead of `MiniTest::Unit.autorun`

Old test output:

```
SSHKit::Backend::TestNetssh
     PASS (0:00:00.214) test_netssh_ext
     PASS (0:00:00.215) test_net_ssh_configuration_options
     PASS (0:00:00.216) test_transfer_summarizer

```

New test output:

```
SSHKit::Backend::TestNetssh
  test_net_ssh_configuration_options                              PASS (0.00s)
  test_transfer_summarizer                                        PASS (0.00s)
  test_netssh_ext                                                 PASS (0.00s)
```
