### PR TITLE
`SSHKit::Backend::Printer#test` now always returns true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ appear at the top.
     @steved
   * `SSHKit::Formatter::Abstract` now accepts an optional Hash of options
     [PR #308](https://github.com/capistrano/sshkit/pull/308) @mattbrictson
+  * `SSHKit::Backend::Printer#test` now always returns true
+    [PR #312](https://github.com/capistrano/sshkit/pull/312) @mikz
 
 ## 1.8.1
 

--- a/lib/sshkit/backends/printer.rb
+++ b/lib/sshkit/backends/printer.rb
@@ -10,6 +10,11 @@ module SSHKit
 
       alias :upload! :execute
       alias :download! :execute
+
+      def test(*)
+        super
+        true
+      end
     end
   end
 end

--- a/test/unit/backends/test_printer.rb
+++ b/test/unit/backends/test_printer.rb
@@ -28,7 +28,7 @@ module SSHKit
       end
 
       def test_test_method
-        printer.test '[ -d /some/file ]'
+        assert printer.test('[ -d /some/file ]'), 'test should return true'
 
         assert_output_lines(
           ' DEBUG [aaaaaa] Running [ -d /some/file ] on example.com',


### PR DESCRIPTION
which makes --dry-run pass the `deploy:check:linked_files`