### PR TITLE
Add `rubocop --lint` to default rake task and Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ rvm:
   - 2.2.2
   - 2.1.6
   - 2.0.0
-script: "rake test:units"
+script: "rake test:units lint"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,16 @@ ruby versions.
 **The Travis build does not run the functional tests,
 so make sure all the tests pass locally before creating your PR.**
 
+## Coding guidelines
+
+This project uses [RuboCop](https://github.com/bbatsov/rubocop) to enforce standard Ruby coding
+guidelines. Currently we run RuboCop's lint rules only, which check for readability issues
+like indentation, ambiguity, and useless/unreachable code.
+
+* Test that your contributions pass with `rake lint`
+* The linter is also run as part of the full test suite with `rake`
+* Note the Travis build will fail and your PR cannot be merged if the linter finds errors
+
 ## Changelog
 
 Most changes should have an accompanying entry in the [CHANGELOG](CHANGELOG.md), unless they

--- a/Rakefile
+++ b/Rakefile
@@ -2,8 +2,9 @@
 
 require 'bundler/gem_tasks'
 require 'rake/testtask'
+require 'rubocop/rake_task'
 
-task :default => :test
+task :default => [:test, :lint]
 
 desc "Run all tests"
 task :test => ['test:units', 'test:functional']
@@ -24,6 +25,11 @@ end
 
 Rake::Task["test:functional"].enhance do
   warn "Remember there are still some VMs running, kill them with `vagrant halt` if you are finished using them."
+end
+
+desc 'Run RuboCop lint checks'
+RuboCop::RakeTask.new(:lint) do |task|
+  task.options = ['--lint']
 end
 
 task "release:rubygem_push" do

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -6,13 +6,12 @@ require "thread"
 # In the case of proxy commands, this can lead to proxy processes leaking
 # And in severe cases can cause deploys to fail due to default file descriptor limits
 # An alternate solution would be to use a different means of generating hash keys
-module Net; module SSH; module Proxy
-  class Command
-    def inspect
-      @command_line_template
-    end
+require "net/ssh/proxy/command"
+class Net::SSH::Proxy::Command
+  def inspect
+    @command_line_template
   end
-end;end;end
+end
 
 module SSHKit
 

--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -23,11 +23,12 @@ module SSHKit
       end
 
       def log_command_data(command, stream_type, stream_data)
-        color = case stream_type
+        color = \
+          case stream_type
           when :stdout then :green
           when :stderr then :red
           else raise "Unrecognised stream_type #{stream_type}, expected :stdout or :stderr"
-        end
+          end
         write_message(Logger::DEBUG, colorize("\t#{stream_data}".chomp, color), command.uuid)
       end
 

--- a/lib/sshkit/mapping_interaction_handler.rb
+++ b/lib/sshkit/mapping_interaction_handler.rb
@@ -4,7 +4,8 @@ module SSHKit
 
     def initialize(mapping, log_level=nil)
       @log_level = log_level
-      @mapping_proc = case mapping
+      @mapping_proc = \
+        case mapping
         when Hash
           lambda do |server_output|
             first_matching_key_value = mapping.find { |k, _v| k === server_output }
@@ -14,7 +15,7 @@ module SSHKit
           mapping
         else
           raise "Unsupported mapping type: #{mapping.class} - only Hash and Proc mappings are supported"
-      end
+        end
     end
 
     def on_data(_command, stream_name, data, channel)

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('minitest', '>= 5.0.0')
   gem.add_development_dependency('minitest-reporters')
   gem.add_development_dependency('rake')
+  gem.add_development_dependency('rubocop')
   gem.add_development_dependency('unindent')
   gem.add_development_dependency('mocha')
 end

--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -101,10 +101,10 @@ module SSHKit
         conn1.expects(:closed?).returns(false)
         conn1.expects(:close)
 
-        entry1 = pool.checkout("conn1"){|*args| conn1 }
+        entry1 = pool.checkout("conn1") { conn1 }
         pool.checkin entry1
         sleep(pool.idle_timeout)
-        pool.checkout("conn2"){|*args| Object.new}
+        pool.checkout("conn2") { Object.new }
       end
 
       def test_closed_connection_is_not_reused
@@ -127,10 +127,10 @@ module SSHKit
         conn1 = mock
         conn1.expects(:closed?).returns(false)
         conn1.expects(:close)
-        entry1 = pool.checkout("conn1"){|*args| conn1 }
+        entry1 = pool.checkout("conn1"){ conn1 }
         pool.checkin entry1
-        entry2 = pool.checkout("conn2", &connect)
-        # entry2 isn't closed if close_connections is called
+        # the following isn't closed if close_connections is called
+        pool.checkout("conn2", &connect)
 
         pool.close_connections
       end

--- a/test/unit/formatters/test_custom.rb
+++ b/test/unit/formatters/test_custom.rb
@@ -58,10 +58,11 @@ module SSHKit
 
   class CustomFormatter < SSHKit::Formatter::Abstract
     def write(obj)
-      original_output << case obj
+      original_output << \
+        case obj
         when SSHKit::Command    then "C #{obj.verbosity} #{obj}"
         when SSHKit::LogMessage then "LM #{obj.verbosity} #{obj}"
-      end
+        end
     end
     alias :<< :write
 


### PR DESCRIPTION
I see there is a [precedent](https://github.com/capistrano/sshkit/pull/275) for running RuboCop's lint checks on the SSHKit codebase, so I thought we should make it an official part of the build process.

This PR does the following:

* Fixes all warnings reported by `rubocop --lint` (there were only a few)
* Explains our usage of RuboCop in CONTRIBUTING
* Adds a `lint` rake task for executing `rubocop --lint`
* Makes linting part of the default rake task
* Adds linting to the Travis build

RuboCop's linting rules are not very controversial (I hope!), so I figure this is a good start. We can perhaps add stricter style guidelines in the future if there is interest.

/cc @leehambley @robd @cshaffer