### PR TITLE
Ability to specify custom runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ appear at the top.
     helper methods and still have easy access to the currently-executing Backend
     without having to use global variables.
     [PR #319](https://github.com/capistrano/sshkit/pull/319) @mattbrictson
+  * Add `SSHKit.config.default_runner` options that allows to override default command runner.
+    This option also accepts a name of the custom runner class.
 
 ## 1.8.1
 

--- a/lib/sshkit/configuration.rb
+++ b/lib/sshkit/configuration.rb
@@ -3,7 +3,7 @@ module SSHKit
   class Configuration
 
     attr_accessor :umask, :output_verbosity
-    attr_writer :output, :backend, :default_env
+    attr_writer :output, :backend, :default_env, :default_runner
 
     def output
       @output ||= use_format(:pretty)
@@ -20,6 +20,10 @@ module SSHKit
 
     def default_env
       @default_env ||= {}
+    end
+
+    def default_runner
+      @default_runner ||= :parallel
     end
 
     def backend

--- a/lib/sshkit/coordinator.rb
+++ b/lib/sshkit/coordinator.rb
@@ -17,7 +17,7 @@ module SSHKit
         when :sequence then Runner::Sequential
         when :groups   then Runner::Group
         else
-          raise RuntimeError, "Don't know how to handle run style #{options[:in].inspect}"
+          options[:in]
         end.new(hosts, options, &block).execute
       else
         Runner::Null.new(hosts, options, &block).execute
@@ -26,13 +26,13 @@ module SSHKit
 
     private
 
-      def default_options
-        { in: :parallel }
-      end
+    def default_options
+      { in: SSHKit.config.default_runner }
+    end
 
-      def resolve_hosts
-        @raw_hosts.collect { |rh| rh.is_a?(Host) ? rh : Host.new(rh) }.uniq
-      end
+    def resolve_hosts
+      @raw_hosts.collect { |rh| rh.is_a?(Host) ? rh : Host.new(rh) }.uniq
+    end
 
   end
 

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -51,6 +51,12 @@ module SSHKit
       assert SSHKit.config.default_env
     end
 
+    def test_default_runner
+      assert_equal :parallel, SSHKit.config.default_runner
+      SSHKit.config.default_runner = :sequence
+      assert_equal :sequence, SSHKit.config.default_runner
+    end
+
     def test_backend
       assert_equal SSHKit::Backend::Netssh, SSHKit.config.backend
       assert SSHKit.config.backend = SSHKit::Backend::Printer


### PR DESCRIPTION
This patch enables ability to specify my own runner class.

```ruby
module SSHKit
  module Runner
    class MyParallel < Abstract
    # ...
    end
  end
end

on roles(:web), in: :my_parallel do
  # …
end
```