### PR TITLE
Add SSHKit::Backend.current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ appear at the top.
     [PR #308](https://github.com/capistrano/sshkit/pull/308) @mattbrictson
   * `SSHKit::Backend::Printer#test` now always returns true
     [PR #312](https://github.com/capistrano/sshkit/pull/312) @mikz
+  * Add `SSHKit::Backend.current` so that Capistrano plugin authors can refactor
+    helper methods and still have easy access to the currently-executing Backend
+    without having to use global variables.
+    [PR #319](https://github.com/capistrano/sshkit/pull/319) @mattbrictson
 
 ## 1.8.1
 

--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -4,6 +4,19 @@ module SSHKit
 
     MethodUnavailableError = Class.new(SSHKit::StandardError)
 
+    # The Backend instance that is running in the current thread. If no Backend
+    # is running, returns `nil` instead.
+    #
+    # Example:
+    #
+    #   on(:local) do
+    #     self == SSHKit::Backend.current # => true
+    #   end
+    #
+    def self.current
+      Thread.current["sshkit_backend"]
+    end
+
     class Abstract
 
       extend Forwardable
@@ -12,7 +25,10 @@ module SSHKit
       attr_reader :host
 
       def run
+        Thread.current["sshkit_backend"] = self
         instance_exec(@host, &@block)
+      ensure
+        Thread.current["sshkit_backend"] = nil
       end
 
       def initialize(host, &block)

--- a/test/unit/backends/test_abstract.rb
+++ b/test/unit/backends/test_abstract.rb
@@ -131,6 +131,28 @@ module SSHKit
         end
       end
 
+      def test_current_refers_to_currently_executing_backend
+        backend = nil
+        current = nil
+
+        backend = ExampleBackend.new do
+          backend = self
+          current = SSHKit::Backend.current
+        end
+        backend.run
+
+        assert_equal(backend, current)
+      end
+
+      def test_current_is_nil_outside_of_the_block
+        backend = ExampleBackend.new do
+          # nothing
+        end
+        backend.run
+
+        assert_nil(SSHKit::Backend.current)
+      end
+
       # Use a concrete ExampleBackend rather than a mock for improved assertion granularity
       class ExampleBackend < Abstract
         attr_writer :full_stdout


### PR DESCRIPTION
This PR adds the `SSHKit::Backend.current` method that I originally introduced in a monkey patch in this Capistrano PR: https://github.com/capistrano/capistrano/pull/1561