### PR TITLE
Reference the correct class instance for ssh options merge

### DIFF
--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -130,7 +130,7 @@ module SSHKit
       end
 
       def with_ssh
-        host.ssh_options = Netssh.config.ssh_options.merge(host.ssh_options || {})
+        host.ssh_options = self.class.config.ssh_options.merge(host.ssh_options || {})
         conn = self.class.pool.checkout(
           String(host.hostname),
           host.username,


### PR DESCRIPTION
I stumbled upon an interesting issue when converting our deployment scripts from Capistrano v2 to v3, namely with trying to pass SSH options via the global configuration (from capistrano itself). Theoretically the global configuration should be merged into host (server) options before the connection is established, in practice that never happened in my scenario. I tracked it down to a combination of a third party cap plugin and an issue in the SSHKit gem itself.

The third part gem overrides the SSHKit backend in capistrano (which is `SSHKit::Backend::Netssh` by default) to a custom one which inherits from the capistrano default one. The capistrano initializer then sets options - including ssh options - to that class instance. Before establishing the connection, SSHKit now merges those into the host options with the following code:

`host.ssh_options = Netssh.config.ssh_options.merge(host.ssh_options || {})`

The problem is that if the backend is something else that inherits from `Netssh`, the options hash referenced here is empty, which is not the expected behavior. The correct way to merge the options here is to use the current class instance hash instead of referencing `Netssh` directly. This ensures it also works in case the backend used is a child class of `Netssh` for example.

