### PR TITLE
Fix race condition in CommandMap#prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ appear at the top.
     [PR #319](https://github.com/capistrano/sshkit/pull/319) @mattbrictson
   * Add `SSHKit.config.default_runner` options that allows to override default command runner.
     This option also accepts a name of the custom runner class.
+  * Fix a race condition experienced in JRuby that could cause multi-server
+    deploys to fail. [PR #322](https://github.com/capistrano/sshkit/pull/322)
+    @mattbrictson
 
 ## 1.8.1
 

--- a/lib/sshkit/command_map.rb
+++ b/lib/sshkit/command_map.rb
@@ -28,8 +28,6 @@ module SSHKit
 
       def [](command)
         @storage[command] ||= []
-
-        @storage[command]
       end
     end
 

--- a/test/unit/test_command_map.rb
+++ b/test/unit/test_command_map.rb
@@ -56,5 +56,14 @@ module SSHKit
       assert_equal map[:rake], "/home/vagrant/.rbenv/bin/rbenv exec bundle exec rake"
     end
 
+    def test_prefix_initialization_is_thread_safe
+      map = CommandMap.new
+      threads = Array.new(3) do
+        Thread.new do
+          (1..1_000).each { |i| assert_equal([], map.prefix[i.to_s]) }
+        end
+      end
+      threads.each(&:join)
+    end
   end
 end


### PR DESCRIPTION
`PrefixProvider#[]` could return `nil` in multi-threaded scenarios due to a race condition involving `||=`, which is not an atomic operation in JRuby.

The test that I added failed with JRuby 9.0.4.0 before the fix; now it passes.

Fixes https://github.com/capistrano/capistrano/issues/1528