### PR TITLE
Allow to disable both connection pooling and pruning idependently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This file is written in reverse chronological order, newer releases will
 appear at the top.
 
 ## `master` (Unreleased)
-
+  * `SSHKit::Backend::Netssh.pool.idle_timeout = 0` doesn't disable connection pooling anymore,
+    only connection expiration. To disable connection polling use `SSHKit::Backend::Netssh.pool.enabled = false`
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
   * make sure working directory for commands is properly cleared after `within` blocks

--- a/README.md
+++ b/README.md
@@ -500,11 +500,16 @@ seconds. This timeout can be changed as follows:
 SSHKit::Backend::Netssh.pool.idle_timeout = 60 # seconds
 ```
 
-If you suspect the connection pooling is causing problems, you can disable the
-pooling behaviour entirely by setting the idle_timeout to zero:
+If you suspect the connection pruning is causing problems, you can disable the
+expiration behaviour entirely by setting the idle_timeout to zero:
 
 ```ruby
 SSHKit::Backend::Netssh.pool.idle_timeout = 0 # disabled
+```
+
+Or even disable the pooling entirely, but it will severely reduce performance:
+```
+SSHKit::Backend::Netssh.pool.enabled = false # disabled
 ```
 
 ## Tunneling and other related SSH themes

--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -73,8 +73,15 @@ module SSHKit
         assert_equal t2[:conn], t3[:conn]
       end
 
-      def test_zero_idle_timeout_disables_reuse
+      def test_zero_idle_timeout_disables_pruning
         pool.idle_timeout = 0
+
+        conn1 = pool.checkout("conn", &connect)
+        assert_nil conn1.expires_at
+      end
+
+      def test_enabled_false_disables_pooling
+        pool.enabled = false
 
         conn1 = pool.checkout("conn", &connect)
         pool.checkin conn1


### PR DESCRIPTION
Ref: https://github.com/capistrano/sshkit/issues/326

By profiling capistrano, it occurred that connection pruning was a significant performance hotspot.

See https://github.com/capistrano/sshkit/issues/326#issuecomment-178939657
> After investigation it's clear that the ConnectionPool put way to much zeal into pruning expired connection.
> The prune_expired method that iterates over all the connections is called both on checkin and on checkout, so it's executed twice per host and per command.
> e.g. if you execute 5 commands, on 10 servers, it will be executed 2 * 5 * 10, 100 times! Also note that it synchronize a mutex, so it's very probable that it kills limits the concurrency.

So much that 12% of the execution time (on a micro benchmark but still) was spent checking expirations.

I think that for many cases just checking is the connection is closed on checkout is enough.

I ran the same benchmark a saw some interesting performance improvements (even though it's always hard to be put an exact number because of the network).
<img width="909" alt="capture d ecran 2016-02-03 a 00 12 37" src="https://cloud.githubusercontent.com/assets/44640/12773562/e20dbf94-ca0a-11e5-837b-aa925bb14a95.png">

NB: This is somewhat backwards incompatible. `idle_timeout = 0` used to disable connection pooling entirely by always reaping connections, while now it actually let connections live indefinitely until they are closed.

If a version bump is not an option, I can make `idle_timeout = 0` disable pooling as well, but then we need something like `idle_timeout = false` to disable connection pruning.

