### PR TITLE
Silence interpreter warnings

### DIFF
--- a/lib/sshkit.rb
+++ b/lib/sshkit.rb
@@ -4,7 +4,7 @@ module SSHKit
 
   class << self
 
-    attr_accessor :config
+    attr_writer :config
 
     def configure
       @@config ||= Configuration.new

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -78,9 +78,11 @@ class SSHKit::Backend::ConnectionPool
     end
   end
 
-  private
+  protected
 
   attr_reader :caches, :timed_out_connections
+
+  private
 
   def cache_enabled?
     idle_timeout && idle_timeout > 0

--- a/lib/sshkit/backends/connection_pool/cache.rb
+++ b/lib/sshkit/backends/connection_pool/cache.rb
@@ -53,9 +53,11 @@ class SSHKit::Backend::ConnectionPool::Cache
     end
   end
 
-  private
+  protected
 
   attr_reader :connections, :idle_timeout, :closer
+
+  private
 
   def fresh?(expires_at)
     expires_at > Time.now

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -5,6 +5,8 @@ module Net
   module SSH
     class Config
       class << self
+        remove_method :default_files
+
         def default_files
           @@default_files + [File.join(Dir.pwd, '.ssh/config')]
         end

--- a/lib/sshkit/configuration.rb
+++ b/lib/sshkit/configuration.rb
@@ -2,7 +2,7 @@ module SSHKit
 
   class Configuration
 
-    attr_accessor :umask, :output_verbosity
+    attr_accessor :umask
     attr_writer :output, :backend, :default_env, :default_runner
 
     def output

--- a/lib/sshkit/host.rb
+++ b/lib/sshkit/host.rb
@@ -99,7 +99,7 @@ module SSHKit
   class SimpleHostParser
 
     def self.suitable?(host_string)
-      !host_string.match(/[:|@]/)
+      !host_string.match(/:|@/)
     end
 
     def initialize(host_string)
@@ -127,7 +127,7 @@ module SSHKit
   class HostWithPortParser < SimpleHostParser
 
     def self.suitable?(host_string)
-      !host_string.match(/[@|\[|\]]/)
+      !host_string.match(/@|\[|\]/)
     end
 
     def port


### PR DESCRIPTION
Rake 11 shipped with warnings enabled by default. These are only some of warnings on require and aren't breaking anything, but might as well clean them up.

```
lib/sshkit.rb:14: warning: method redefined; discarding old config
lib/sshkit/host.rb:130: warning: character class has duplicated range: /[@|\[|\]]/
lib/sshkit/configuration.rb:33: warning: method redefined; discarding old output_verbosity
lib/sshkit/configuration.rb:37: warning: method redefined; discarding old output_verbosity=
lib/sshkit/backends/connection_pool.rb:83: warning: private attribute?
lib/sshkit/backends/connection_pool.rb:83: warning: private attribute?
lib/sshkit/backends/connection_pool/cache.rb:58: warning: private attribute?
lib/sshkit/backends/connection_pool/cache.rb:58: warning: private attribute?
lib/sshkit/backends/connection_pool/cache.rb:58: warning: private attribute?
lib/sshkit/backends/netssh.rb:8: warning: method redefined; discarding old default_files
/opt/homebrew/var/rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/net-ssh-3.0.2/lib/net/ssh/config.rb:50: warning: previous definition of default_files was here
```