### PR TITLE
Explicitly close the connection pool using at_exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ appear at the top.
 
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * SSHKit now explicitly closes its pooled SSH connections when Ruby exits;
+    this fixes `zlib(finalizer): the stream was freed prematurely` warnings
+    [PR #343](https://github.com/capistrano/sshkit/pull/343) @mattbrictson
   * Allow command map entries (`SSHKit::CommandMap#[]`) to be Procs
     [PR #310]((https://github.com/capistrano/sshkit/pull/310)
     @mikz

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -1,3 +1,4 @@
+require 'English'
 require 'net/ssh'
 require 'net/scp'
 
@@ -44,7 +45,12 @@ module SSHKit
         end
       end
 
+      # Note that this pool must be explicitly closed before Ruby exits to
+      # ensure the underlying IO objects are properly cleaned up. We register an
+      # at_exit handler to do this automatically, as long as Ruby is exiting
+      # cleanly (i.e. without an exception).
       @pool = SSHKit::Backend::ConnectionPool.new
+      at_exit { @pool.close_connections if @pool && !$ERROR_INFO }
 
       class << self
         attr_accessor :pool


### PR DESCRIPTION
This fixes the `zlib(finalizer): the stream was freed prematurely` warning that is printed by net-ssh when Ruby exits without closing the SSH connection first.

Fixes #342.

I could have placed the `at_exit` registration inside `ConnectionPool#initialize` (as I [originally suggested](https://github.com/capistrano/sshkit/issues/342#issuecomment-210202285)), but then that would mean all instances of ConnectionPool would never be garbage collected (the `at_exit` block would retain a reference to `self`). Doing it in the `Netssh` class definition seemed like a better place to put it.

/cc @leehambley @mfazekas