### PR TITLE
Support future ruby

### DIFF
--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -131,9 +131,9 @@ module SSHKit
 
     def verbosity
       if (vb = options[:verbosity])
-        case vb.class.name
-        when 'Symbol' then return Logger.const_get(vb.to_s.upcase)
-        when 'Fixnum' then return vb
+        case vb
+        when Symbol then return Logger.const_get(vb.to_s.upcase)
+        when Integer then return vb
         end
       else
         Logger::INFO


### PR DESCRIPTION
On ruby-head, Fixnum and Bignum are Unified.

https://github.com/ruby/ruby/commit/f9727c12cc8fbc5f752f5983be1f14bb976e5a13

And capistrano fail with this error when use ruby-head 

```
NoMethodError: undefined method `>=' for nil:NilClass
```

This patch will support both old and new ruby.