### PR TITLE
Add check for :known_hosts support in net-ssh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ appear at the top.
 
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * Fixed compatibility with net-ssh > 3.1.0. @byroot
+    [#357](https://github.com/capistrano/sshkit/issues/357)
 
 ## [1.11.0][] (2016-06-14)
 

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -33,8 +33,14 @@ module SSHKit
 
         private
 
-        def default_options
-          @default_options ||= {known_hosts: SSHKit::Backend::Netssh::KnownHosts.new}
+        if Net::SSH::VALID_OPTIONS.include?(:known_hosts)
+          def default_options
+            @default_options ||= {known_hosts: SSHKit::Backend::Netssh::KnownHosts.new}
+          end
+        else
+          def default_options
+            @default_options ||= {}
+          end
         end
       end
 


### PR DESCRIPTION
Should fix https://github.com/capistrano/sshkit/issues/357

Disclaimer: I haven't had the time to test it properly yet.