### PR TITLE
Fix for #359

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ appear at the top.
 
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * Fixed a crash occurring when `Host@keys` was set to a non-Enumerable.
+    @xavierholt [PR #360](https://github.com/capistrano/sshkit/pull/360)
 
 ## [1.11.1][] (2016-06-17)
 

--- a/lib/sshkit/host.rb
+++ b/lib/sshkit/host.rb
@@ -17,7 +17,7 @@ module SSHKit
     end
 
     def keys
-      @keys
+      Array(@keys)
     end
 
     def initialize(host_string_or_options_hash)


### PR DESCRIPTION
Make sure that `Host#keys` always returns an array, avoiding https://github.com/capistrano/sshkit/issues/359