### PR TITLE
Fix "unnecessary splat" violation in RuboCop 0.43

### DIFF
--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -150,7 +150,7 @@ module SSHKit
       end
 
       def command(args, options)
-        SSHKit::Command.new(*[*args, options.merge({in: pwd_path, env: @env, host: @host, user: @user, group: @group})])
+        SSHKit::Command.new(*args, options.merge({in: pwd_path, env: @env, host: @host, user: @user, group: @group}))
       end
 
     end


### PR DESCRIPTION
Upgrading to RuboCop 0.43.0 revealed a new lint warning about an "unnecessary splat operator". I've fixed it.