### PR TITLE
Use cp_r in local backend with recursive option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ appear at the top.
 
   * Your contribution here!
   * [#390](https://github.com/capistrano/sshkit/pull/390): Properly wrap Ruby StandardError w/ add'l context - [@mattbrictson](https://github.com/mattbrictson)
+  * [#372](https://github.com/capistrano/sshkit/pull/372): Use cp_r in local backend with recursive option - [@okuramasafumi](https://github.com/okuramasafumi)
 
 ## [1.12.0][] (2017-02-10)
 

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -10,9 +10,13 @@ module SSHKit
         super(Host.new(:local), &block)
       end
 
-      def upload!(local, remote, _options = {})
+      def upload!(local, remote, options = {})
         if local.is_a?(String)
-          FileUtils.cp(local, remote)
+          if options[:recursive]
+            FileUtils.cp_r(local, remote)
+          else
+            FileUtils.cp(local, remote)
+          end
         else
           File.open(remote, "wb") do |f|
             IO.copy_stream(local, f)

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -10,6 +10,30 @@ module SSHKit
         SSHKit.config.output = SSHKit::Formatter::BlackHole.new($stdout)
       end
 
+      def test_upload
+        Dir.mktmpdir do |dir|
+          File.new("#{dir}/local", 'w')
+          Local.new do
+            upload!("#{dir}/local", "#{dir}/remote")
+          end.run
+          assert File.exist?("#{dir}/remote")
+        end
+      end
+
+      def test_upload_recursive
+        Dir.mktmpdir do |dir|
+          Dir.mkdir("#{dir}/local")
+          File.new("#{dir}/local/file1", 'w')
+          File.new("#{dir}/local/file2", 'w')
+          Local.new do
+            upload!("#{dir}/local", "#{dir}/remote", recursive: true)
+          end.run
+          assert File.directory?("#{dir}/remote")
+          assert File.exist?("#{dir}/remote/file1")
+          assert File.exist?("#{dir}/remote/file2")
+        end
+      end
+
       def test_capture
         captured_command_result = ''
         Local.new do


### PR DESCRIPTION
When `recursive` optionfor `upload!` method is true, `local` argument is likely to be a String representing a directory, but `FileUtils.cp` doesn't accept it. So here we use `FileUtils.cp_r` instead.
