### PR TITLE
Extract ssh channel callbacks into separate methods

### DIFF
--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -104,50 +104,40 @@ module SSHKit
       def execute_command(cmd)
         output.log_command_start(cmd)
         cmd.started = true
-        exit_status = nil
+        result = Struct.new(:exit_status).new(nil)
         with_ssh do |ssh|
           ssh.open_channel do |chan|
             chan.request_pty if Netssh.config.pty
-            chan.exec cmd.to_command do |_ch, _success|
-              chan.on_data do |ch, data|
-                cmd.on_stdout(ch, data)
-                output.log_command_data(cmd, :stdout, data)
-              end
-              chan.on_extended_data do |ch, _type, data|
-                cmd.on_stderr(ch, data)
-                output.log_command_data(cmd, :stderr, data)
-              end
-              chan.on_request("exit-status") do |_ch, data|
-                exit_status = data.read_long
-              end
-              #chan.on_request("exit-signal") do |ch, data|
-              #  # TODO: This gets called if the program is killed by a signal
-              #  # might also be a worthwhile thing to report
-              #  exit_signal = data.read_string.to_i
-              #  warn ">>> " + exit_signal.inspect
-              #  output.log_command_killed(cmd, exit_signal)
-              #end
-              chan.on_open_failed do |_ch|
-                # TODO: What do do here?
-                # I think we should raise something
-              end
-              chan.on_process do |_ch|
-                # TODO: I don't know if this is useful
-              end
-              chan.on_eof do |_ch|
-                # TODO: chan sends EOF before the exit status has been
-                # writtend
-              end
-            end
+            chan.exec(cmd.to_command) { set_handlers(chan, cmd, result) }
             chan.wait
           end
           ssh.loop
         end
         # Set exit_status and log the result upon completion
-        if exit_status
-          cmd.exit_status = exit_status
+        if result.exit_status
+          cmd.exit_status = result.exit_status
           output.log_command_exit(cmd)
         end
+      end
+
+      def set_handlers(channel, command, result)
+        channel.on_data                   { |*args| handle_data          command, *args }
+        channel.on_extended_data          { |*args| handle_extended_data command, *args }
+        channel.on_request('exit-status') { |*args| handle_exit_status   result,  *args }
+      end
+
+      def handle_data(command, channel, data)
+        command.on_stdout(channel, data)
+        output.log_command_data(command, :stdout, data)
+      end
+
+      def handle_extended_data(command, channel, _type, data)
+        command.on_stderr(channel, data)
+        output.log_command_data(command, :stderr, data)
+      end
+
+      def handle_exit_status(result, _channel, data)
+        result.exit_status = data.read_long
       end
 
       def with_ssh(&block)


### PR DESCRIPTION
Deep nesting of blocks is hard to read and understand.

I have extracted them into several small methods:

* Small individual methods called `handle_EVENT` for each type of event
  that is processed by the library.

* The main setup method `set_handlers` that only sets channel callbacks.
  It does not try to handle the events itself but rather just calls
  the corresponding handler method for each callback.

  In other words, it acts as an event dispatcher.

I believe that this structure is well-maintainable:

* If it is necessary to add a new event handler, one could add a new
  `handle_EVENT` method and a new line to the `set_handlers` method,
  not a whole new block to `execute_command`.

* If it is necessary to change how an event is handled, one could only
  change the corresponding `handle_EVENT` method.

Unfortunately, it was necessary to introduce a whole object with
a method in place of a simple local variable `exit_status`
because only then it was possible to set the status inside
the `handle_exit_status` method.

The new `result` object might hold other values in the future though,
set in a similar way, so that might count as a future-proof thing.

I have deleted commented out code and empty blocks. I'm going to create issues for them instead if you greenlight this.