### PR TITLE
do not prefix exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ appear at the top.
 
   * Add your entries below here, remember to credit yourself however you want
     to be credited!
+  * Do not prefix `exec` command
+    [PR #378](https://github.com/capistrano/sshkit/pull/378) @dreyks
 
 ## [1.11.4][] (2016-11-02)
 

--- a/lib/sshkit/command_map.rb
+++ b/lib/sshkit/command_map.rb
@@ -62,7 +62,7 @@ module SSHKit
 
     def defaults
       Hash.new do |hash, command|
-        if %w{if test time}.include? command.to_s
+        if %w{if test time exec}.include? command.to_s
           hash[command] = command.to_s
         else
           hash[command] = "/usr/bin/env #{command}"


### PR DESCRIPTION
`exec` is a shell builtin so `/usr/bin/env exec` results in `/usr/bin/env: exec: No such file or directory`