### PR TITLE
Set up Danger!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: ruby
 rvm:
-  - 2.3.0
+  - 2.3.3
   - 2.2.4
   - 2.1.8
   - 2.0.0
+include:
+  # Run Danger only once, on 2.3.3
+  - rvm: 2.3.3
+    before_script: bundle exec danger
 script: "rake test:units lint"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ appear at the top.
 
 ## [Unreleased][]
 
-  * Add your entries below here, remember to credit yourself however you want
-    to be credited!
+  * Your contribution here!
   * Do not prefix `exec` command
     [PR #378](https://github.com/capistrano/sshkit/pull/378) @dreyks
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,54 @@
+# Adapted from https://github.com/ruby-grape/danger/blob/master/Dangerfile
+# Q: What is a Dangerfile, anyway? A: See http://danger.systems/
+
+# ------------------------------------------------------------------------------
+# Additional pull request data
+# ------------------------------------------------------------------------------
+project_name = github.pr_json["base"]["repo"]["name"]
+pr_number = github.pr_json["number"]
+pr_url = github.pr_json["_links"]["html"]["href"]
+
+# ------------------------------------------------------------------------------
+# What changed?
+# ------------------------------------------------------------------------------
+has_lib_changes = !git.modified_files.grep(/^lib/).empty?
+has_test_changes = !git.modified_files.grep(/^test/).empty?
+has_changelog_changes = git.modified_files.include?("CHANGELOG.md")
+
+# ------------------------------------------------------------------------------
+# You've made changes to lib, but didn't write any tests?
+# ------------------------------------------------------------------------------
+if has_lib_changes && !has_test_changes
+  warn("There are code changes, but no corresponding tests. "\
+       "Please include tests if this PR introduces any modifications in "\
+       "#{project_name}'s behavior.",
+       :sticky => false)
+end
+
+# ------------------------------------------------------------------------------
+# Have you updated CHANGELOG.md?
+# ------------------------------------------------------------------------------
+if !has_changelog_changes && has_lib_changes
+  markdown <<-MARKDOWN
+Here's an example of a CHANGELOG.md entry (place it immediately under the `* Your contribution here!` line):
+
+```markdown
+* [##{pr_number}](#{pr_url}): #{github.pr_title} - [@#{github.pr_author}](https://github.com/#{github.pr_author}).
+```
+MARKDOWN
+  warn("Please update CHANGELOG.md with a description of your changes. "\
+       "If this PR is not a user-facing change (e.g. just refactoring), "\
+       "you can disregard this.", :sticky => false)
+end
+
+# ------------------------------------------------------------------------------
+# Did you remove the CHANGELOG's "Your contribution here!" line?
+# ------------------------------------------------------------------------------
+if has_changelog_changes
+  unless IO.read("CHANGELOG.md") =~ /^\* Your contribution here/i
+    fail(
+      "Please put the `* Your contribution here!` line back into CHANGELOG.md.",
+      :sticky => false
+    )
+  end
+end

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')
 
+  gem.add_development_dependency('danger')
   gem.add_development_dependency('minitest', '>= 5.0.0')
   gem.add_development_dependency('minitest-reporters')
   gem.add_development_dependency('rake')


### PR DESCRIPTION
Add Danger to SSHKit, just like we recently did in https://github.com/capistrano/capistrano/pull/1795.

"Danger" is a gem that automatically runs certain sanity checks against GitHub pull requests. Whenever an SSHKit PR is opened, Danger will check whether a CHANGELOG entry was included, and whether tests were included, and add a comment to the PR if there are violations.