### PR TITLE
Capistrano support is done on Stack Overflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,19 @@
 # Contributing to SSHKit
 
+ * Use [Stack Overflow][so] for Capistrano-related how-to questions and support
  * [**Don't** push your pull request](http://www.igvita.com/2011/12/19/dont-push-your-pull-requests/)
  * [**Do** write a good commit message](http://365git.tumblr.com/post/3308646748/writing-git-commit-messages)
+
+
+## Getting help
+
+Most users encounter SSHKit primarily by using Capistrano. If you have a question about using
+SSHKit in context of Capistrano, please use the [capistrano tag on Stack Overflow][so].
+
+If you are using SSHKit directly, or if you think you've found a bug in SSHKit, please open a
+[GitHub issue](https://github.com/capistrano/sshkit/issues).
+
+[so]: http://stackoverflow.com/questions/tagged/capistrano
 
 ## Ruby versions
 


### PR DESCRIPTION
Clarify in `CONTRIBUTING.md` that Capistrano-related support and how-to questions should be directed to Stack Overflow.

I created this PR because we were missing this topic from our contribution guidelines, as mentioned here: https://github.com/capistrano/sshkit/issues/375#issuecomment-255774226