### PR TITLE
Fix `Use assert_nil if expecting nil` Minitest warnings

### DIFF
--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -50,8 +50,8 @@ module SSHKit
       end
 
       def test_connections_are_reused_if_checked_in
-        conn1 = pool.with(connect, "conn") {}
-        conn2 = pool.with(connect, "conn") {}
+        conn1 = pool.with(connect, "conn") { |c| c }
+        conn2 = pool.with(connect, "conn") { |c| c }
 
         assert_equal conn1, conn2
       end

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -218,7 +218,7 @@ module SSHKit
 
     def test_setting_exit_status
       c = Command.new(:whoami, raise_on_non_zero_exit: false)
-      assert_equal nil, c.exit_status
+      assert_nil c.exit_status
       assert c.exit_status = 1
       assert_equal 1, c.exit_status
     end

--- a/test/unit/test_host.rb
+++ b/test/unit/test_host.rb
@@ -75,7 +75,7 @@ module SSHKit
 
     def test_arbitrary_host_properties
       h = Host.new('example.com')
-      assert_equal nil, h.properties.roles
+      assert_nil h.properties.roles
       assert h.properties.roles = [:web, :app]
       assert_equal [:web, :app], h.properties.roles
     end


### PR DESCRIPTION
This PR fixes the following Minitest warnings:

```
Use assert_nil if expecting nil from test/unit/test_host.rb:78:in `test_arbitrary_host_properties'. This will fail in MT6.
Use assert_nil if expecting nil from test/unit/test_command.rb:221:in `test_setting_exit_status'. This will fail in MT6.
```

Also fix a buggy test in `test_connection_pool.rb`.