### PR TITLE
Ability to specify default runner config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ appear at the top.
 
 ## [Unreleased][]
 
-  * Your contribution here!
+  * Add `SSHKit.config.default_runner_config` option that allows overriding default runner configs.
 
 ## [1.11.5][] (2016-12-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ appear at the top.
 
 ## [Unreleased][]
 
+  * Your contribution here!
   * Add `SSHKit.config.default_runner_config` option that allows overriding default runner configs.
 
 ## [1.11.5][] (2016-12-16)

--- a/README.md
+++ b/README.md
@@ -136,6 +136,26 @@ it too hard.
 Sequential runs were intended to be used for rolling restarts, amongst other
 similar use-cases.
 
+The default runner can be set with the `SSHKit.config.default_runner` option.  For
+example:
+ ```ruby
+SSHKit.config.default_runner = :parallel
+SSHKit.config.default_runner = :sequence
+SSHKit.config.default_runner = :groups
+SSHKit.config.default_runner = MyRunner # A custom runner
+```
+
+If more control over the default runner is needed, the `SSHKit.config.default_runner_config`
+can be set.
+```ruby
+# Set the runner and then the config for the runner
+SSHKit.config.default_runner = :sequence
+SSHKit.config.default_runner_config = { wait: 5 }
+
+# Or just set everything once
+SSHKit.config.default_runner_config = { in: :sequence, wait: 5 }
+```
+
 ## Synchronisation
 
 The `on()` block is the unit of synchronisation, one `on()` block will wait

--- a/lib/sshkit/configuration.rb
+++ b/lib/sshkit/configuration.rb
@@ -3,7 +3,7 @@ module SSHKit
   class Configuration
 
     attr_accessor :umask
-    attr_writer :output, :backend, :default_env, :default_runner
+    attr_writer :output, :backend, :default_env, :default_runner, :default_runner_config
 
     def output
       @output ||= use_format(:pretty)
@@ -27,6 +27,10 @@ module SSHKit
 
     def default_runner
       @default_runner ||= :parallel
+    end
+
+    def default_runner_config
+      @default_runner_config ||= {}
     end
 
     def backend

--- a/lib/sshkit/configuration.rb
+++ b/lib/sshkit/configuration.rb
@@ -3,7 +3,7 @@ module SSHKit
   class Configuration
 
     attr_accessor :umask
-    attr_writer :output, :backend, :default_env, :default_runner, :default_runner_config
+    attr_writer :output, :backend, :default_env, :default_runner
 
     def output
       @output ||= use_format(:pretty)
@@ -30,7 +30,13 @@ module SSHKit
     end
 
     def default_runner_config
-      @default_runner_config ||= {}
+      @default_runner_config ||= { in: default_runner }
+    end
+
+    def default_runner_config=(config_hash)
+      config = config_hash.dup
+      SSHKit.config.default_runner = config.delete(:in) if config[:in]
+      @default_runner_config = config.merge(in: SSHKit.config.default_runner)
     end
 
     def backend

--- a/lib/sshkit/coordinator.rb
+++ b/lib/sshkit/coordinator.rb
@@ -27,7 +27,7 @@ module SSHKit
     private
 
     def default_options
-      { in: SSHKit.config.default_runner }.merge(SSHKit.config.default_runner_config)
+      SSHKit.config.default_runner_config
     end
 
     def resolve_hosts

--- a/lib/sshkit/coordinator.rb
+++ b/lib/sshkit/coordinator.rb
@@ -27,7 +27,7 @@ module SSHKit
     private
 
     def default_options
-      { in: SSHKit.config.default_runner }
+      { in: SSHKit.config.default_runner }.merge(SSHKit.config.default_runner_config)
     end
 
     def resolve_hosts

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -59,9 +59,15 @@ module SSHKit
 
     def test_default_runner_config
       config_hash = { wait: 5 }
-      assert_equal Hash.new, SSHKit.config.default_runner_config
-      SSHKit.config.default_runner = config_hash
-      assert_equal config_hash, SSHKit.config.default_runner
+      config_hash_with_runner = { in: :groups, limit: 5 }
+      default_hash = { in: SSHKit.config.default_runner }
+
+      assert_equal default_hash, SSHKit.config.default_runner_config
+      SSHKit.config.default_runner_config = config_hash
+      assert_equal default_hash.merge(config_hash), SSHKit.config.default_runner_config
+      SSHKit.config.default_runner_config = config_hash_with_runner
+      assert_equal config_hash_with_runner, SSHKit.config.default_runner_config
+      assert_equal config_hash_with_runner[:in], SSHKit.config.default_runner
     end
 
     def test_backend

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -57,6 +57,13 @@ module SSHKit
       assert_equal :sequence, SSHKit.config.default_runner
     end
 
+    def test_default_runner_config
+      config_hash = { wait: 5 }
+      assert_equal Hash.new, SSHKit.config.default_runner_config
+      SSHKit.config.default_runner = config_hash
+      assert_equal config_hash, SSHKit.config.default_runner
+    end
+
     def test_backend
       assert_equal SSHKit::Backend::Netssh, SSHKit.config.backend
       assert SSHKit.config.backend = SSHKit::Backend::Printer


### PR DESCRIPTION
The `SSHKit.config.default_runner` configuration option has the ability to set the default runner, but users cannot configure the default runner.  This adds the `SSHKit.config.default_runner_config` setting, that a user can use to configure the runner.

For example, a user might want to override the default group size of 2 in the following manner:

```ruby
SSHKit.config.default_runner = :groups
SSHKit.config.default_runner_config = { limit: 10 }
```