### PR TITLE
Properly wrap Ruby StandardError w/ add'l context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ appear at the top.
 ## [Unreleased][]
 
   * Your contribution here!
+  * [#390](https://github.com/capistrano/sshkit/pull/390): Properly wrap Ruby StandardError w/ add'l context - [@mattbrictson](https://github.com/mattbrictson)
 
 ## [1.12.0][] (2017-02-10)
 

--- a/lib/sshkit/runners/parallel.rb
+++ b/lib/sshkit/runners/parallel.rb
@@ -10,7 +10,7 @@ module SSHKit
           Thread.new(host) do |h|
             begin
               backend(h, &block).run
-            rescue StandardError => e
+            rescue ::StandardError => e
               e2 = ExecuteError.new e
               raise e2, "Exception while executing #{host.user ? "as #{host.user}@" : "on host "}#{host}: #{e.message}"
             end

--- a/lib/sshkit/runners/sequential.rb
+++ b/lib/sshkit/runners/sequential.rb
@@ -26,7 +26,7 @@ module SSHKit
       private
       def run_backend(host, &block)
         backend(host, &block).run
-      rescue StandardError => e
+      rescue ::StandardError => e
         e2 = ExecuteError.new e
         raise e2, "Exception while executing #{host.user ? "as #{host.user}@" : "on host "}#{host}: #{e.message}"
       end

--- a/test/unit/runners/test_group.rb
+++ b/test/unit/runners/test_group.rb
@@ -1,0 +1,17 @@
+require "helper"
+require "sshkit"
+
+module SSHKit
+  module Runner
+    class TestGroup < UnitTest
+      def test_wraps_ruby_standard_error_in_execute_error
+        localhost = Host.new(:local)
+        runner = Group.new([localhost]) { raise "oh no!" }
+        error = assert_raises(SSHKit::Runner::ExecuteError) do
+          runner.execute
+        end
+        assert_match(/while executing.*localhost/, error.message)
+      end
+    end
+  end
+end

--- a/test/unit/runners/test_parallel.rb
+++ b/test/unit/runners/test_parallel.rb
@@ -1,0 +1,18 @@
+require "helper"
+require "sshkit"
+
+module SSHKit
+  module Runner
+    class TestParallel < UnitTest
+      def test_wraps_ruby_standard_error_in_execute_error
+        host = Host.new("deployer@example")
+        runner = Parallel.new([host]) { raise "oh no!" }
+        error = assert_raises(SSHKit::Runner::ExecuteError) do
+          runner.execute
+        end
+        assert_match(/deployer@example/, error.message)
+        assert_match(/oh no!/, error.message)
+      end
+    end
+  end
+end

--- a/test/unit/runners/test_sequential.rb
+++ b/test/unit/runners/test_sequential.rb
@@ -1,0 +1,18 @@
+require "helper"
+require "sshkit"
+
+module SSHKit
+  module Runner
+    class TestSequential < UnitTest
+      def test_wraps_ruby_standard_error_in_execute_error
+        host = Host.new("deployer@example")
+        runner = Sequential.new([host]) { raise "oh no!" }
+        error = assert_raises(SSHKit::Runner::ExecuteError) do
+          runner.execute
+        end
+        assert_match(/deployer@example/, error.message)
+        assert_match(/oh no!/, error.message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Prior to this PR, any Ruby StandardError (such as socket connection errors) would not be rescued or interpreted by SSHKit. In a scenario where you are running commands on multiple hosts, this meant the error would be devoid of any context, like on which host the error occurred.

This behavior was actually a mistake: we were intending to rescue and wrap all Ruby StandardErrors, but the rescue clause was written such that it only caught `SSHKit::StandardError`, which is something entirely different.

Fix this by referring to the correct constant, and add unit tests.

Fixes #389.