### PR TITLE
Fix open two connections with changed cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ appear at the top.
   * Your contribution here!
   * [#390](https://github.com/capistrano/sshkit/pull/390): Properly wrap Ruby StandardError w/ add'l context - [@mattbrictson](https://github.com/mattbrictson)
   * [#372](https://github.com/capistrano/sshkit/pull/372): Use cp_r in local backend with recursive option - [@okuramasafumi](https://github.com/okuramasafumi)
+  * [#392](https://github.com/capistrano/sshkit/pull/392): Fix open two connections with changed cache key - [@shirosaki](https://github.com/shirosaki)
 
 ## [1.12.0][] (2017-02-10)
 

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -122,6 +122,7 @@ class SSHKit::Backend::ConnectionPool
 
     caches.synchronize do
       caches[new_key] = caches.delete(cache.key)
+      cache.key = new_key
     end
   end
 

--- a/lib/sshkit/backends/connection_pool/cache.rb
+++ b/lib/sshkit/backends/connection_pool/cache.rb
@@ -1,7 +1,7 @@
 # A Cache holds connections for a given key. Each connection is stored along
 # with an expiration time so that its idle duration can be measured.
 class SSHKit::Backend::ConnectionPool::Cache
-  attr_reader :key
+  attr_accessor :key
 
   def initialize(key, idle_timeout, closer)
     @key = key

--- a/lib/sshkit/backends/connection_pool/cache.rb
+++ b/lib/sshkit/backends/connection_pool/cache.rb
@@ -1,7 +1,10 @@
 # A Cache holds connections for a given key. Each connection is stored along
 # with an expiration time so that its idle duration can be measured.
 class SSHKit::Backend::ConnectionPool::Cache
-  def initialize(idle_timeout, closer)
+  attr_reader :key
+
+  def initialize(key, idle_timeout, closer)
+    @key = key
     @connections = []
     @connections.extend(MonitorMixin)
     @idle_timeout = idle_timeout
@@ -51,6 +54,10 @@ class SSHKit::Backend::ConnectionPool::Cache
       connections.map(&:last).each(&closer)
       connections.clear
     end
+  end
+
+  def same_key?(other_key)
+    key == other_key
   end
 
   protected

--- a/lib/sshkit/backends/connection_pool/nil_cache.rb
+++ b/lib/sshkit/backends/connection_pool/nil_cache.rb
@@ -8,4 +8,8 @@ SSHKit::Backend::ConnectionPool::NilCache = Struct.new(:closer) do
   def push(conn)
     closer.call(conn)
   end
+
+  def same_key?(_key)
+    true
+  end
 end

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -36,11 +36,19 @@ module SSHKit
         if Net::SSH::VALID_OPTIONS.include?(:known_hosts)
           def default_options
             @default_options ||= {known_hosts: SSHKit::Backend::Netssh::KnownHosts.new}
+            assign_defaults
           end
         else
           def default_options
             @default_options ||= {}
+            assign_defaults
           end
+        end
+
+        # Set default options early for ConnectionPool cache key
+        def assign_defaults
+          Net::SSH.assign_defaults(@default_options)
+          @default_options
         end
       end
 

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -59,7 +59,7 @@ module SSHKit
           capture(:uname)
           host_ssh_options = host.ssh_options
         end.run
-        assert_equal [:forward_agent, :paranoid, :known_hosts].sort, host_ssh_options.keys.sort
+        assert_equal [:forward_agent, :paranoid, :known_hosts, :logger, :password_prompt].sort, host_ssh_options.keys.sort
         assert_equal false, host_ssh_options[:forward_agent]
         assert_equal true, host_ssh_options[:paranoid]
         assert_instance_of SSHKit::Backend::Netssh::KnownHosts, host_ssh_options[:known_hosts]

--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -134,6 +134,17 @@ module SSHKit
           pool.close_connections
         end
       end
+
+      def test_connections_with_changed_args_is_reused
+        connect_change_args = ->(*args) { args[2][:a] << "a"; args[2][:b] = []; Object.new }
+        ssh_options = { :a => [] }
+        option1 = ["conn", "user", ssh_options.dup]
+        conn1 = pool.with(connect_change_args, *option1) { |c| c }
+        option2 = ["conn", "user", ssh_options.dup]
+        conn2 = pool.with(connect_change_args, *option2) { |c| c }
+
+        assert_equal conn1, conn2
+      end
     end
   end
 end

--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -136,12 +136,10 @@ module SSHKit
       end
 
       def test_connections_with_changed_args_is_reused
-        connect_change_args = ->(*args) { args[2][:a] << "a"; args[2][:b] = []; Object.new }
-        ssh_options = { :a => [] }
-        option1 = ["conn", "user", ssh_options.dup]
-        conn1 = pool.with(connect_change_args, *option1) { |c| c }
-        option2 = ["conn", "user", ssh_options.dup]
-        conn2 = pool.with(connect_change_args, *option2) { |c| c }
+        options = { known_hosts: "foo" }
+        connect_change_options = ->(*args) { args.last[:known_hosts] = "bar"; Object.new }
+        conn1 = pool.with(connect_change_options, "arg", options) { |c| c }
+        conn2 = pool.with(connect_change_options, "arg", options) { |c| c }
 
         assert_equal conn1, conn2
       end


### PR DESCRIPTION
`args.to_s` is used for cache key of connection pooling.
`ssh_options` in `args` is changed while creating connections in
`connection_factory.call(*args)`.
Resetting cache key using changed `args` prevents cache miss.

This is a workaround for #369.