### PR TITLE
Fix net-ssh default options with net-ssh < 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ appear at the top.
 ## [Unreleased][]
 
   * Your contribution here!
+  * [#397](https://github.com/capistrano/sshkt/pull/397): Fix NoMethodError assign_defaults with net-ssh older than 4.0.0 - [@shirosaki](https://github.com/shirosaki)
 
 ## [1.13.0][] (2017-03-24)
 

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -47,7 +47,16 @@ module SSHKit
 
         # Set default options early for ConnectionPool cache key
         def assign_defaults
-          Net::SSH.assign_defaults(@default_options)
+          if Net::SSH.respond_to?(:assign_defaults)
+            Net::SSH.assign_defaults(@default_options)
+          else
+            # net-ssh < 4.0.0 doesn't have assign_defaults
+            unless @default_options.key?(:logger)
+              require 'logger'
+              @default_options[:logger] = ::Logger.new(STDERR)
+              @default_options[:logger].level = ::Logger::FATAL
+            end
+          end
           @default_options
         end
       end


### PR DESCRIPTION
net-ssh < 4.0.0 doesn't have Net::SSH.aassing_defaults.
Fallback to logger assignment.
https://github.com/net-ssh/net-ssh/blob/v3.2.0/lib/net/ssh.rb#L211

Fix for #396 
I've confirmed `rake test:units` with net-ssh 3.2.0.