### PR TITLE
Simplify code used to sanitize command

### DIFF
--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -21,10 +21,9 @@ module SSHKit
     def initialize(*args)
       raise ArgumentError, "Must pass arguments to Command.new" if args.empty?
       @options = default_options.merge(args.extract_options!)
-      @command = args.shift.to_s.strip.to_sym
+      @command = sanitize_command(args.shift)
       @args    = args
       @options.symbolize_keys!
-      sanitize_command!
       @stdout, @stderr, @full_stdout, @full_stderr = String.new, String.new, String.new, String.new
     end
 
@@ -222,16 +221,8 @@ module SSHKit
       }
     end
 
-    def sanitize_command!
-      command.to_s.strip!
-      if command.to_s.match("\n")
-        @command = String.new.tap do |cs|
-          command.to_s.lines.each do |line|
-            cs << line.strip
-            cs << '; ' unless line == command.to_s.lines.to_a.last
-          end
-        end
-      end
+    def sanitize_command(cmd)
+      cmd.to_s.lines.map(&:strip).join("; ")
     end
 
     def call_interaction_handler(stream_name, data, channel)

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -16,13 +16,18 @@ module SSHKit
       end
     end
 
-    def test_using_a_heredoc
+    def test_multiple_lines_are_stripped_of_extra_space_and_joined_by_semicolons
       c = Command.new <<-EOHEREDOC
         if test ! -d /var/log; then
           echo "Example"
         fi
       EOHEREDOC
       assert_equal "if test ! -d /var/log; then; echo \"Example\"; fi", c.to_command
+    end
+
+    def test_leading_and_trailing_space_is_stripped
+      c = Command.new(" echo hi ")
+      assert_equal "echo hi", c.to_command
     end
 
     def test_including_the_env


### PR DESCRIPTION
I was browsing the `command.rb` code and found a `sanitize_command!` method that was way more complicated than it needed to be. This PR refactors it to a one-liner. I also added a missing unit test.