### PR TITLE
Fix RuboCop failure in master due to inappropriate shebang in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-#!/usr/bin/env rake
-
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rubocop/rake_task'

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('minitest-reporters')
   gem.add_development_dependency('rainbow', '~> 2.1.0')
   gem.add_development_dependency('rake')
-  gem.add_development_dependency('rubocop')
+  gem.add_development_dependency('rubocop', "~> 0.49.1")
   gem.add_development_dependency('mocha')
 end


### PR DESCRIPTION
Fixes this RuboCop violation:

```
Rakefile:1:1: W: Lint/ScriptPermission: Script file Rakefile doesn't have execute permission.
^^^^^^^^^^^^^^^^^^^
```

I also pinned the RuboCop version to prevent new releases of RuboCop from breaking the build.