### PR TITLE
Teach upload! and download! to respect within(...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ appear at the top.
 ## [Unreleased][]
 
   * Your contribution here!
+  * [#408](https://github.com/capistrano/sshkit/pull/408): Teach upload! and download! to respect within(...) - [@sj26](https://github.com/sj26)
 
 ## [1.14.0][] (2017-06-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ appear at the top.
   * Your contribution here!
   * [#408](https://github.com/capistrano/sshkit/pull/408): Teach upload! and download! to respect within(...) - [@sj26](https://github.com/sj26)
 
+### Potentially breaking changes
+
+  * `upload!` and `download!` now support relative remote paths which are
+    relative to the `within` working directory. They were previously documented
+    as only supporting absolute paths, but relative paths still worked relative
+    to the remote working directory. If you rely on the previous behaviour you
+    may need to adjust your code.
+
 ## [1.14.0][] (2017-06-30)
 
 ### Breaking changes

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -90,6 +90,7 @@ end
 ```
 
 ## Download a file from disk
+
 ```ruby
 on roles(:all) do
   puts 'Downloading DB Backup File'
@@ -106,8 +107,18 @@ on hosts do |host|
 end
 ```
 
-**Note:** The `upload!()` method doesn't honor the values of `within()`, `as()`
-etc, this will be improved as the library matures, but we're not there yet.
+Upload and download will respect the `within()` directories:
+
+```ruby
+on hosts do |host|
+  within 'my/app/directory' do
+    upload! 'database.yml', 'config/database.yml'
+  end
+end
+```
+
+**Note:** The `upload!()` method doesn't honor the values of `as()` etc, this
+will be improved as the library matures, but we're not there yet.
 
 ## Upload a file from a stream
 

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,8 @@ end
 if Gem::Requirement.new('>= 2.1.0').satisfied_by?(Gem::Version.new(RUBY_VERSION))
   gem 'chandler', '>= 0.1.1'
 end
+
+# public_suffix 3+ requires ruby 2.1+
+if Gem::Requirement.new('< 2.1').satisfied_by?(Gem::Version.new(RUBY_VERSION))
+  gem 'public_suffix', '< 3'
+end

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -11,6 +11,7 @@ module SSHKit
       end
 
       def upload!(local, remote, options = {})
+        remote = File.join(pwd_path, remote) unless remote[0] == "/"
         if local.is_a?(String)
           if options[:recursive]
             FileUtils.cp_r(local, remote)
@@ -25,6 +26,7 @@ module SSHKit
       end
 
       def download!(remote, local=nil, _options = {})
+        remote = File.join(pwd_path, remote) unless remote[0] == "/"
         if local.nil?
           FileUtils.cp(remote, File.basename(remote))
         else

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -11,7 +11,7 @@ module SSHKit
       end
 
       def upload!(local, remote, options = {})
-        remote = File.join(pwd_path, remote) unless remote[0] == "/"
+        remote = File.join(pwd_path, remote) unless remote.start_with?("/")
         if local.is_a?(String)
           if options[:recursive]
             FileUtils.cp_r(local, remote)
@@ -26,7 +26,7 @@ module SSHKit
       end
 
       def download!(remote, local=nil, _options = {})
-        remote = File.join(pwd_path, remote) unless remote[0] == "/"
+        remote = File.join(pwd_path, remote) unless remote.start_with?("/")
         if local.nil?
           FileUtils.cp(remote, File.basename(remote))
         else

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -63,7 +63,7 @@ module SSHKit
 
       def upload!(local, remote, options = {})
         summarizer = transfer_summarizer('Uploading', options)
-        remote = File.join(pwd_path, remote) unless remote[0] == "/"
+        remote = File.join(pwd_path, remote) unless remote.start_with?("/")
         with_ssh do |ssh|
           ssh.scp.upload!(local, remote, options, &summarizer)
         end
@@ -71,7 +71,7 @@ module SSHKit
 
       def download!(remote, local=nil, options = {})
         summarizer = transfer_summarizer('Downloading', options)
-        remote = File.join(pwd_path, remote) unless remote[0] == "/"
+        remote = File.join(pwd_path, remote) unless remote.start_with?("/")
         with_ssh do |ssh|
           ssh.scp.download!(remote, local, options, &summarizer)
         end

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -63,6 +63,7 @@ module SSHKit
 
       def upload!(local, remote, options = {})
         summarizer = transfer_summarizer('Uploading', options)
+        remote = File.join(pwd_path, remote) unless remote[0] == "/"
         with_ssh do |ssh|
           ssh.scp.upload!(local, remote, options, &summarizer)
         end
@@ -70,6 +71,7 @@ module SSHKit
 
       def download!(remote, local=nil, options = {})
         summarizer = transfer_summarizer('Downloading', options)
+        remote = File.join(pwd_path, remote) unless remote[0] == "/"
         with_ssh do |ssh|
           ssh.scp.download!(remote, local, options, &summarizer)
         end

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -20,6 +20,23 @@ module SSHKit
         end
       end
 
+      def test_upload_within
+        file_contents = "Some Content"
+        actual_file_contents = nil
+        Dir.mktmpdir do |dir|
+          Local.new do
+            within dir do
+              execute(:mkdir, "-p", "foo")
+              within "foo" do
+                upload!(StringIO.new(file_contents), "bar")
+              end
+            end
+            actual_file_contents = capture(:cat, File.join(dir, "foo", "bar"))
+          end.run
+          assert_equal file_contents, actual_file_contents
+        end
+      end
+
       def test_upload_recursive
         Dir.mktmpdir do |dir|
           Dir.mkdir("#{dir}/local")

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -103,6 +103,23 @@ module SSHKit
         assert_equal "Some Content\nWith a newline and trailing spaces    \n ", actual_file_contents
       end
 
+      def test_upload_within
+        file_name = SecureRandom.uuid
+        file_contents = "Some Content"
+        dir_name = SecureRandom.uuid
+        actual_file_contents = ""
+        Netssh.new(a_host) do |_host|
+          within("/tmp") do
+            execute :mkdir, "-p", dir_name
+            within(dir_name) do
+              upload!(StringIO.new(file_contents), file_name)
+            end
+          end
+          actual_file_contents = capture(:cat, "/tmp/#{dir_name}/#{file_name}", strip: false)
+        end.run
+        assert_equal file_contents, actual_file_contents
+      end
+
       def test_upload_string_io
         file_contents = ""
         Netssh.new(a_host) do |_host|


### PR DESCRIPTION
I've been using sshkit to automate some deployment tasks recently and found the tasks would be easier if `upload!` and `download!` respected my `within(...)` context.

They already seem to work with remote relative paths which use the remote cwd, but don't respect the `within(...)` path stack. But we can just prepend `pwd_path` to remote path if it's relative to make it work.

This might be a breaking change for some users, although the documentation does say to always use absolute paths.

Also I have no idea how to test this, beyond doing a whole bunch of manual testing against a real ssh remote. 😅 