### PR TITLE
call #to_s on remote so Pathnames don't go :boom:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ appear at the top.
 ## [Unreleased][]
 
   * Your contribution here!
+  * [#410](https://github.com/capistrano/sshkit/pull/410): call #to_s on remote so Pathnames don't go :boom: - [@UnderpantsGnome](https://github.com/UnderpantsGnome)
 
 ## [1.15.0][] (2017-11-03)
 

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -11,7 +11,7 @@ module SSHKit
       end
 
       def upload!(local, remote, options = {})
-        remote = File.join(pwd_path, remote) unless remote.start_with?("/")
+        remote = File.join(pwd_path, remote) unless remote.to_s.start_with?("/")
         if local.is_a?(String)
           if options[:recursive]
             FileUtils.cp_r(local, remote)
@@ -26,7 +26,7 @@ module SSHKit
       end
 
       def download!(remote, local=nil, _options = {})
-        remote = File.join(pwd_path, remote) unless remote.start_with?("/")
+        remote = File.join(pwd_path, remote) unless remote.to_s.start_with?("/")
         if local.nil?
           FileUtils.cp(remote, File.basename(remote))
         else

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -63,7 +63,7 @@ module SSHKit
 
       def upload!(local, remote, options = {})
         summarizer = transfer_summarizer('Uploading', options)
-        remote = File.join(pwd_path, remote) unless remote.start_with?("/")
+        remote = File.join(pwd_path, remote) unless remote.to_s.start_with?("/")
         with_ssh do |ssh|
           ssh.scp.upload!(local, remote, options, &summarizer)
         end
@@ -71,7 +71,7 @@ module SSHKit
 
       def download!(remote, local=nil, options = {})
         summarizer = transfer_summarizer('Downloading', options)
-        remote = File.join(pwd_path, remote) unless remote.start_with?("/")
+        remote = File.join(pwd_path, remote) unless remote.to_s.start_with?("/")
         with_ssh do |ssh|
           ssh.scp.download!(remote, local, options, &summarizer)
         end

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -20,6 +20,16 @@ module SSHKit
         end
       end
 
+      def test_upload_via_pathname
+        Dir.mktmpdir do |dir|
+          File.new("#{dir}/local", 'w')
+          Local.new do
+            upload!("#{dir}/local", Pathname.new("#{dir}/remote"))
+          end.run
+          assert File.exist?("#{dir}/remote")
+        end
+      end
+
       def test_upload_within
         file_contents = "Some Content"
         actual_file_contents = nil

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -145,6 +145,16 @@ module SSHKit
         assert_equal File.open(file_name).read, file_contents
       end
 
+      def test_upload_via_pathname
+        file_contents = ""
+        Netssh.new(a_host) do |_host|
+          file_name = Pathname.new(File.join("/tmp", SecureRandom.uuid))
+          upload!(StringIO.new('example_io'), file_name)
+          file_contents = download!(file_name)
+        end.run
+        assert_equal "example_io", file_contents
+      end
+
       def test_interaction_handler
         captured_command_result = nil
         Netssh.new(a_host) do


### PR DESCRIPTION
This fixes #409 