### PR TITLE
Restore ability to work with a relative path outside a `within` block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ appear at the top.
 
   * Your contribution here!
   * [#410](https://github.com/capistrano/sshkit/pull/410): call #to_s on remote so Pathnames don't go :boom: - [@UnderpantsGnome](https://github.com/UnderpantsGnome)
-  * [#411](https://github.com/capistrano/sshkit/pull/410): fix upload!/dowbload! relative to user dir that broke in #408 -  [@Fjan](https://github.com/Fjan)
+  * [#411](https://github.com/capistrano/sshkit/pull/410): fix upload!/download! relative to user dir that broke in #408 -  [@Fjan](https://github.com/Fjan)
 
 ## [1.15.0][] (2017-11-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ appear at the top.
 
   * Your contribution here!
   * [#410](https://github.com/capistrano/sshkit/pull/410): call #to_s on remote so Pathnames don't go :boom: - [@UnderpantsGnome](https://github.com/UnderpantsGnome)
+  * [#411](https://github.com/capistrano/sshkit/pull/410): fix upload!/dowbload! relative to user dir that broke in #408 -  [@Fjan](https://github.com/Fjan)
 
 ## [1.15.0][] (2017-11-03)
 

--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -11,7 +11,7 @@ module SSHKit
       end
 
       def upload!(local, remote, options = {})
-        remote = File.join(pwd_path, remote) unless remote.to_s.start_with?("/")
+        remote = File.join(pwd_path, remote) unless remote.to_s.start_with?("/") || pwd_path.nil?
         if local.is_a?(String)
           if options[:recursive]
             FileUtils.cp_r(local, remote)
@@ -26,7 +26,7 @@ module SSHKit
       end
 
       def download!(remote, local=nil, _options = {})
-        remote = File.join(pwd_path, remote) unless remote.to_s.start_with?("/")
+        remote = File.join(pwd_path, remote) unless remote.to_s.start_with?("/") || pwd_path.nil?
         if local.nil?
           FileUtils.cp(remote, File.basename(remote))
         else

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -63,7 +63,7 @@ module SSHKit
 
       def upload!(local, remote, options = {})
         summarizer = transfer_summarizer('Uploading', options)
-        remote = File.join(pwd_path, remote) unless remote.to_s.start_with?("/")
+        remote = File.join(pwd_path, remote) unless remote.to_s.start_with?("/") || pwd_path.nil?
         with_ssh do |ssh|
           ssh.scp.upload!(local, remote, options, &summarizer)
         end
@@ -71,7 +71,7 @@ module SSHKit
 
       def download!(remote, local=nil, options = {})
         summarizer = transfer_summarizer('Downloading', options)
-        remote = File.join(pwd_path, remote) unless remote.to_s.start_with?("/")
+        remote = File.join(pwd_path, remote) unless remote.to_s.start_with?("/") || pwd_path.nil?
         with_ssh do |ssh|
           ssh.scp.download!(remote, local, options, &summarizer)
         end


### PR DESCRIPTION
This restores the behaviour of 1.14 for relative paths used in upload! / download! It fixes the issues introduced by #408 where scripts written for the old behaviour raise an exception