### PR TITLE
Fix cache key generation performance for connection pooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ appear at the top.
 ## [Unreleased][]
 
   * Your contribution here!
+  * [#417](https://github.com/capistrano/sshkit/pull/417): Cache key generation for connections becomes slow when `known_hosts` is a valid `net/ssh` options and `known_hosts` file is big. This changes the cache key generation and fixes performance issue - [@ElvinEfendi](https://github.com/ElvinEfendi).
 
 ## [1.15.1][] (2017-11-18)
 

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -88,7 +88,7 @@ class SSHKit::Backend::ConnectionPool
   private
 
   def cache_key_for_connection_args(args)
-    args.to_s
+    args.hash
   end
 
   def cache_enabled?


### PR DESCRIPTION
The PR https://github.com/net-ssh/net-ssh/pull/308/ introduced a new `known_hosts` options that sshkit uses as a default option: https://github.com/capistrano/sshkit/blob/master/lib/sshkit/backends/netssh.rb#L38. It gets passed to `Net::SSH.start` at https://github.com/capistrano/sshkit/blob/master/lib/sshkit/backends/connection_pool.rb#L59 through https://github.com/capistrano/sshkit/blob/master/lib/sshkit/backends/netssh.rb#L176 as part of `args`. The same `args` is used to generate cache key for an established connection(https://github.com/capistrano/sshkit/blob/master/lib/sshkit/backends/connection_pool.rb#L90). Once the connection is established the default known_hosts gets populated by `Net::SSH`. `know_hosts` file can include thousands of entries. That means every time `cache_key_for_connection_args` is called, Ruby has to do `to_s` on that huge object. This impacts performance for every single command executed.

As a fix the PR changes `Arrayto_s` to use `Array#hash` instead. The following shows the issue and impact of the change.

StackProf output without the changes in this PR:
```
> sshkit-test (v-1.15.1)$ bundle exec ruby main.rb
1.15.1
  INFO [6caeca9c] Running /usr/bin/env date on examplehost.com
args changed
  INFO [6caeca9c] Finished in 1.399 seconds with exit status 0 (successful).
  INFO [724692cb] Running /usr/bin/env date on examplehost.com
  INFO [724692cb] Finished in 0.211 seconds with exit status 0 (successful).
  INFO [d1a80064] Running echo done on examplehost.com
  INFO [d1a80064] Finished in 0.208 seconds with exit status 0 (successful).
> sshkit-test (v-1.15.1)$ stackprof tmp/stackprof.dump
==================================
  Mode: wall(1000)
  Samples: 1803 (0.66% miss rate)
  GC: 154 (8.54%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1649  (91.5%)        1078  (59.8%)     SSHKit::Runner::Parallel#execute
       255  (14.1%)         255  (14.1%)     SSHKit::Backend::ConnectionPool#cache_key_for_connection_args
       154   (8.5%)         154   (8.5%)     (garbage collection)
       101   (5.6%)          90   (5.0%)     OpenSSL::PKey::EC.read_keyblob
       176   (9.8%)          39   (2.2%)     Net::SSH::Buffer#read_keyblob
        35   (1.9%)          31   (1.7%)     Net::SSH::Buffer#read
        27   (1.5%)          27   (1.5%)     SSHKit::Backend::Netssh::KnownHostsKeys#parse_hostlist
        24   (1.3%)          24   (1.3%)     Net::SSH::Buffer#initialize
        22   (1.2%)          22   (1.2%)     SSHKit::Backend::Netssh::KnownHostsKeys#empty_line?
       286  (15.9%)          12   (0.7%)     SSHKit::Backend::Netssh::KnownHostsKeys#parse_line
        31   (1.7%)          12   (0.7%)     Net::SSH::Buffer#read_long
         9   (0.5%)           9   (0.5%)     SSHKit::Backend::Netssh::KnownHostsKeys#supported_type?
       295  (16.4%)           9   (0.5%)     SSHKit::Backend::Netssh::KnownHostsKeys#parse_file
        36   (2.0%)           9   (0.5%)     Net::SSH::Buffer#read_bignum
       216  (12.0%)           6   (0.3%)     SSHKit::Backend::Netssh::KnownHostsKeys#parse_key
         4   (0.2%)           4   (0.2%)     Net::SSH::Buffer#length
         3   (0.2%)           3   (0.2%)     OpenSSL::PKey::DH#valid?
         3   (0.2%)           3   (0.2%)     Net::SSH::Compat.io_select
         1   (0.1%)           1   (0.1%)     Net::SSH::Config.load
         1   (0.1%)           1   (0.1%)     Net::SSH::Authentication::KeyManager#each_identity
         1   (0.1%)           1   (0.1%)     Net::SSH::Buffer#write_byte
         5   (0.3%)           1   (0.1%)     Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1#generate_key
         1   (0.1%)           1   (0.1%)     Net::SSH::Buffer#write_long
         2   (0.1%)           1   (0.1%)     Net::SSH::Proxy::Command#open
       186  (10.3%)           1   (0.1%)     Net::SSH::Buffer#read_key
         1   (0.1%)           1   (0.1%)     #<OpenSSL::Cipher:0x00007f8995a16230>.update
         4   (0.2%)           1   (0.1%)     Net::SSH::Transport::PacketStream#poll_next_packet
       158   (8.8%)           1   (0.1%)     SSHKit::Backend::ConnectionPool#update_key_if_args_changed
        99   (5.5%)           1   (0.1%)     SSHKit::Backend::ConnectionPool#find_cache
         2   (0.1%)           1   (0.1%)     Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1#send_kexinit
```

StackProf output with the changes in this PR applied:
```
> sshkit-test (v-1.15.1)$ bundle exec ruby main.rb
1.15.1
  INFO [a4de68c4] Running /usr/bin/env date on examplehost.com
  INFO [a4de68c4] Finished in 1.513 seconds with exit status 0 (successful).
  INFO [9b8e4800] Running /usr/bin/env date on examplehost.com
  INFO [9b8e4800] Finished in 0.082 seconds with exit status 0 (successful).
  INFO [94847518] Running echo done on examplehost.com
  INFO [94847518] Finished in 0.075 seconds with exit status 0 (successful).
> sshkit-test (v-1.15.1)$ stackprof tmp/stackprof.dump
==================================
  Mode: wall(1000)
  Samples: 1658 (0.72% miss rate)
  GC: 79 (4.76%)
==================================
     TOTAL    (pct)     SAMPLES    (pct)     FRAME
      1579  (95.2%)        1254  (75.6%)     SSHKit::Runner::Parallel#execute
        98   (5.9%)          92   (5.5%)     OpenSSL::PKey::EC.read_keyblob
        79   (4.8%)          79   (4.8%)     (garbage collection)
       186  (11.2%)          44   (2.7%)     Net::SSH::Buffer#read_keyblob
        36   (2.2%)          34   (2.1%)     Net::SSH::Buffer#read
        27   (1.6%)          27   (1.6%)     Net::SSH::Buffer#initialize
        27   (1.6%)          27   (1.6%)     SSHKit::Backend::Netssh::KnownHostsKeys#empty_line?
        21   (1.3%)          21   (1.3%)     SSHKit::Backend::Netssh::KnownHostsKeys#parse_hostlist
        14   (0.8%)          14   (0.8%)     SSHKit::Backend::Netssh::KnownHostsKeys#supported_type?
        44   (2.7%)          13   (0.8%)     Net::SSH::Buffer#read_bignum
        39   (2.4%)          11   (0.7%)     Net::SSH::Buffer#read_long
       299  (18.0%)          10   (0.6%)     SSHKit::Backend::Netssh::KnownHostsKeys#parse_line
       303  (18.3%)           4   (0.2%)     SSHKit::Backend::Netssh::KnownHostsKeys#parse_file
         4   (0.2%)           4   (0.2%)     Net::SSH::Compat.io_select
       227  (13.7%)           3   (0.2%)     SSHKit::Backend::Netssh::KnownHostsKeys#parse_key
         3   (0.2%)           3   (0.2%)     OpenSSL::PKey::DH#valid?
         2   (0.1%)           2   (0.1%)     Net::SSH::Buffer.from
         2   (0.1%)           2   (0.1%)     Net::SSH::Buffer#length
         1   (0.1%)           1   (0.1%)     Net::SSH::Config.load
        48   (2.9%)           1   (0.1%)     Net::SSH::Buffer#read_string
         1   (0.1%)           1   (0.1%)     Net::SSH::Transport::Kex::DiffieHellmanGroup1SHA1#send_kexinit
         1   (0.1%)           1   (0.1%)     Net::SSH::Buffer#write_bignum
         8   (0.5%)           1   (0.1%)     Net::SSH::Connection::EventLoop#process
         1   (0.1%)           1   (0.1%)     Net::SSH::Authentication::Agent#connect!
         1   (0.1%)           1   (0.1%)     Net::SSH::Connection::Channel#on_request
         1   (0.1%)           1   (0.1%)     SSHKit::Host#local?
         1   (0.1%)           1   (0.1%)     #<OpenSSL::Cipher:0x00007fc2d29aedd0>.xor!
         2   (0.1%)           1   (0.1%)     #<OpenSSL::Cipher:0x00007fc2d29aedd0>.update
         1   (0.1%)           1   (0.1%)     #<OpenSSL::Cipher:0x00007fc2d29ae6f0>.increment_counter!
         2   (0.1%)           1   (0.1%)     Net::SSH::Transport::PacketStream#poll_next_packet
```

Here is the content of `main.rb`
```
require 'stackprof'
require 'sshkit'
require 'sshkit/dsl'
require 'sshkit/version'
require 'stackprof'
include SSHKit::DSL

puts SSHKit::VERSION
hosts = ['examplehost.com']

StackProf.run(mode: :wall, out: 'tmp/stackprof.dump', interval: 1000) do
  on hosts do
    execute 'date'
  end

  on hosts do
    execute 'date'
  end

  on hosts do
    execute 'echo done'
  end
end
```