### PR TITLE
Use hostname username as cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ appear at the top.
 ## [Unreleased][]
 
   * Your contribution here!
+  * [#418](https://github.com/capistrano/sshkit/pull/418): Cache key generation for connections becomes slow when `known_hosts` is a valid `net/ssh` options and `known_hosts` file is big. This changes the cache key generation logic to use `hostname` and `username` only and fixes performance issue - [@ElvinEfendi](https://github.com/ElvinEfendi).
 
 ## [1.15.1][] (2017-11-18)
 

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -51,7 +51,7 @@ class SSHKit::Backend::ConnectionPool
 
   # Creates a new connection or reuses a cached connection (if possible) and
   # yields the connection to the given block. Connections are created by
-  # invoking the `connection_factory` proc with the given `args`. The arguments
+  # invoking the `connection_factory` proc with the given `args`. The first two arguments
   # are used to construct a key used for caching.
   def with(connection_factory, *args)
     cache = find_cache(args)

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -61,9 +61,6 @@ class SSHKit::Backend::ConnectionPool
     yield(conn)
   ensure
     cache.push(conn) unless conn.nil?
-    # Sometimes the args mutate as a result of opening a connection. In this
-    # case we need to update the cache key to match the new args.
-    update_key_if_args_changed(cache, args)
   end
 
   # Immediately remove all cached connections, without closing them. This only
@@ -87,8 +84,9 @@ class SSHKit::Backend::ConnectionPool
 
   private
 
+  # First two arguments are hostname and username.
   def cache_key_for_connection_args(args)
-    args.to_s
+    args[0, 2]
   end
 
   def cache_enabled?
@@ -112,17 +110,6 @@ class SSHKit::Backend::ConnectionPool
       caches[key] ||= begin
         Cache.new(key, idle_timeout, method(:silently_close_connection_later))
       end
-    end
-  end
-
-  # Update cache key with changed args to prevent cache miss
-  def update_key_if_args_changed(cache, args)
-    new_key = cache_key_for_connection_args(args)
-    return if cache.same_key?(new_key)
-
-    caches.synchronize do
-      caches[new_key] = caches.delete(cache.key)
-      cache.key = new_key
     end
   end
 

--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -124,7 +124,6 @@ module SSHKit
         refute_equal conn1, conn2
       end
 
-
       def test_close_connections
         conn1 = mock
         conn1.expects(:closed?).twice.returns(false)

--- a/test/unit/backends/test_connection_pool.rb
+++ b/test/unit/backends/test_connection_pool.rb
@@ -49,9 +49,9 @@ module SSHKit
         refute_equal conn1, conn2
       end
 
-      def test_connections_are_reused_if_checked_in
-        conn1 = pool.with(connect, "conn") { |c| c }
-        conn2 = pool.with(connect, "conn") { |c| c }
+      def test_connections_are_reused_if_hostname_and_username_are_same
+        conn1 = pool.with(connect, "example.com", "deploy") { |c| c }
+        conn2 = pool.with(connect, "example.com", "deploy") { |c| c }
 
         assert_equal conn1, conn2
       end
@@ -110,12 +110,20 @@ module SSHKit
         refute_equal conn1, conn2
       end
 
-      def test_connections_with_different_args_are_not_reused
+      def test_connections_with_different_hostnames_are_not_reused
         conn1 = pool.with(connect, "conn1") { |c| c }
         conn2 = pool.with(connect, "conn2") { |c| c }
 
         refute_equal conn1, conn2
       end
+
+      def test_connections_with_same_hostnames_and_different_usernames_are_not_reused
+        conn1 = pool.with(connect, "example.com", "deploy") { |c| c }
+        conn2 = pool.with(connect, "example.com", "root") { |c| c }
+
+        refute_equal conn1, conn2
+      end
+
 
       def test_close_connections
         conn1 = mock
@@ -135,11 +143,11 @@ module SSHKit
         end
       end
 
-      def test_connections_with_changed_args_is_reused
+      def test_connections_are_reused_even_if_the_other_args_are_different
         options = { known_hosts: "foo" }
         connect_change_options = ->(*args) { args.last[:known_hosts] = "bar"; Object.new }
-        conn1 = pool.with(connect_change_options, "arg", options) { |c| c }
-        conn2 = pool.with(connect_change_options, "arg", options) { |c| c }
+        conn1 = pool.with(connect_change_options, "example.com", "deploy", options) { |c| c }
+        conn2 = pool.with(connect_change_options, "example.com", "deploy", options) { |c| c }
 
         assert_equal conn1, conn2
       end


### PR DESCRIPTION
This is an another solution to fix the issue described at https://github.com/capistrano/sshkit/pull/417. Please refer to the description of that PR for the details.

The assumption is `hostname` and `username` should be enough to identify a connection.