### PR TITLE
Fix escaped quotes bug in Command#group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ appear at the top.
 
 ## [Unreleased][]
 
+  * [#422](https://github.com/capistrano/sshkit/pull/422): Command#group incorrectly escapes double quotes, resulting in a a syntax error when specifying the group execution using `as`. This issue manifested when user command quotes changed from double quotes to single quotes. This fix removes the double quote escaping - [@pblesi](https://github.com/pblesi).
   * Your contribution here!
 
 ## [1.16.0][] (2018-02-03)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ appear at the top.
 
 ## [Unreleased][]
 
-  * [#422](https://github.com/capistrano/sshkit/pull/422): Command#group incorrectly escapes double quotes, resulting in a a syntax error when specifying the group execution using `as`. This issue manifested when user command quotes changed from double quotes to single quotes. This fix removes the double quote escaping - [@pblesi](https://github.com/pblesi).
+  * [#425](https://github.com/capistrano/sshkit/pull/425): Command#group incorrectly escapes double quotes, resulting in a a syntax error when specifying the group execution using `as`. This issue manifested when user command quotes changed from double quotes to single quotes. This fix removes the double quote escaping - [@pblesi](https://github.com/pblesi).
   * Your contribution here!
 
 ## [1.16.0][] (2018-02-03)

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -182,7 +182,7 @@ module SSHKit
 
     def group(&_block)
       return yield unless options[:group]
-      "sg #{options[:group]} -c \\\"%s\\\"" % %Q{#{yield}}
+      "sg #{options[:group]} -c \"%s\"" % %Q{#{yield}}
       # We could also use the so-called heredoc format perhaps:
       #"newgrp #{options[:group]} <<EOC \\\"%s\\\" EOC" % %Q{#{yield}}
     end

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -182,7 +182,7 @@ module SSHKit
 
     def group(&_block)
       return yield unless options[:group]
-      "sg #{options[:group]} -c \"%s\"" % %Q{#{yield}}
+      %Q(sg #{options[:group]} -c "#{yield}")
       # We could also use the so-called heredoc format perhaps:
       #"newgrp #{options[:group]} <<EOC \\\"%s\\\" EOC" % %Q{#{yield}}
     end

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -42,6 +42,20 @@ module SSHKit
         ], command_lines
       end
 
+      def test_group_netssh
+        Netssh.new(a_host) do
+          as user: :root, group: :admin do
+           execute :touch, 'restart.txt'
+          end
+        end.run
+
+        command_lines = @output.lines.select { |line| line.start_with?('Command:') }
+        assert_equal [
+          "Command: if ! sudo -u root whoami > /dev/null; then echo \"You cannot switch to user 'root' using sudo, please check the sudoers file\" 1>&2; false; fi\n",
+          "Command: sudo -u root -- sh -c 'sg admin -c \"/usr/bin/env touch restart.txt\"'\n"
+        ], command_lines
+      end
+
       def test_capture
         captured_command_result = nil
         Netssh.new(a_host) do |_host|

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -102,12 +102,12 @@ module SSHKit
 
     def test_working_as_a_given_group
       c = Command.new(:whoami, group: :devvers)
-      assert_equal "sg devvers -c \\\"/usr/bin/env whoami\\\"", c.to_command
+      assert_equal "sg devvers -c \"/usr/bin/env whoami\"", c.to_command
     end
 
     def test_working_as_a_given_user_and_group
       c = Command.new(:whoami, user: :anotheruser, group: :devvers)
-      assert_equal "sudo -u anotheruser -- sh -c 'sg devvers -c \\\"/usr/bin/env whoami\\\"'", c.to_command
+      assert_equal "sudo -u anotheruser -- sh -c 'sg devvers -c \"/usr/bin/env whoami\"'", c.to_command
     end
 
     def test_umask

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -102,12 +102,12 @@ module SSHKit
 
     def test_working_as_a_given_group
       c = Command.new(:whoami, group: :devvers)
-      assert_equal "sg devvers -c \"/usr/bin/env whoami\"", c.to_command
+      assert_equal 'sg devvers -c "/usr/bin/env whoami"', c.to_command
     end
 
     def test_working_as_a_given_user_and_group
       c = Command.new(:whoami, user: :anotheruser, group: :devvers)
-      assert_equal "sudo -u anotheruser -- sh -c 'sg devvers -c \"/usr/bin/env whoami\"'", c.to_command
+      assert_equal %Q(sudo -u anotheruser -- sh -c 'sg devvers -c "/usr/bin/env whoami"'), c.to_command
     end
 
     def test_umask


### PR DESCRIPTION
Command#group incorrectly escapes double quotes, resulting in a syntax
error when specifying the group a command should be executed as. This
issue manifested when user command quotes [changed from double quotes to
single quotes](https://github.com/capistrano/sshkit/commit/fbe177541288720e927292e4b7a6141031cd8a56#diff-4eaa2c55e6802df7b49a8e7a2f7584d5). This fix removes the double quote escaping in order to prevent a syntax error when executing the command.

This addresses issue https://github.com/capistrano/sshkit/issues/424