### PR TITLE
Remove gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ more servers.
 
 [![Gem Version](https://badge.fury.io/rb/sshkit.svg)](https://rubygems.org/gems/sshkit)
 [![Build Status](https://travis-ci.org/capistrano/sshkit.svg?branch=master)](https://travis-ci.org/capistrano/sshkit)
-[![Dependency Status](https://gemnasium.com/capistrano/sshkit.svg)](https://gemnasium.com/capistrano/sshkit)
 
 ## How might it work?
 


### PR DESCRIPTION
The Gemnasium badge on our README now says: `FIXME Migrate to GitLab`. This is because Gemnasium was acquired by GitLab and shut down: https://docs.gitlab.com/ee/user/project/import/gemnasium.html

I think solution is to just remove the badge.