### PR TITLE
Upgrade development dependencies to be compatible with net-ssh 5.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,3 @@ end
 if Gem::Requirement.new('< 2.1').satisfied_by?(Gem::Version.new(RUBY_VERSION))
   gem 'public_suffix', '< 3'
 end
-
-# rbnacl-libsodium > 1.0.15.1 requires Ruby 2.2.6+
-if Gem::Requirement.new('< 2.2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION))
-  gem 'rbnacl-libsodium', '<= 1.0.15.1'
-end

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -29,6 +29,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('mocha')
 
   gem.add_development_dependency('bcrypt_pbkdf')
-  gem.add_development_dependency('rbnacl', '~> 3.4')
-  gem.add_development_dependency('rbnacl-libsodium')
+  gem.add_development_dependency('ed25519', '>= 1.2', '< 2.0')
 end


### PR DESCRIPTION
This fixes the following error when running `rake test:functional`:

    NotImplementedError: unsupported key type `ssh-ed25519'
    net-ssh requires the following gems for ed25519 support:
     * ed25519 (>= 1.2, < 2.0)
     * bcrypt_pbkdf (>= 1.0, < 2.0)
    See https://github.com/net-ssh/net-ssh/issues/565 for more information
    Gem::LoadError : "ed25519 is not part of the bundle. Add it to your Gemfile."

Before:

```
Finished in 2.75947s
24 tests, 14 assertions, 1 failures, 14 errors, 0 skips
rake aborted!
Command failed with status (1)
```

After:

```
Finished in 12.09465s
24 tests, 34 assertions, 0 failures, 0 errors, 0 skips
```

Fixes #431 