### PR TITLE
Consistent verbosity configuration inside #capture and #test methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ appear at the top.
 ## [Unreleased][]
 
   * Your contribution here!
+  * [#435](https://github.com/capistrano/sshkit/pull/435): Consistent verbosity configuration #capture and #test methods - [@NikolayRys](https://github.com/NikolayRys)
 
 ## [1.17.0][] (2018-07-07)
 

--- a/README.md
+++ b/README.md
@@ -514,6 +514,8 @@ produces a large amount of noise. They are tagged with a verbosity option on
 the `Command` instances of `Logger::DEBUG`. The default configuration for
 output verbosity is available to override with `SSHKit.config.output_verbosity=`,
 and defaults to `Logger::INFO`.
+Another way to is to provide a hash containing `{verbosity: Logger::INFO}` as
+a last parameter for the method call.
 
 At present the `Logger::WARN`, `ERROR` and `FATAL` are not used.
 

--- a/lib/sshkit/backends/abstract.rb
+++ b/lib/sshkit/backends/abstract.rb
@@ -55,7 +55,7 @@ module SSHKit
       end
 
       def test(*args)
-        options = args.extract_options!.merge(raise_on_non_zero_exit: false, verbosity: Logger::DEBUG)
+        options = { verbosity: Logger::DEBUG, raise_on_non_zero_exit: false }.merge(args.extract_options!)
         create_command_and_execute(args, options).success?
       end
 

--- a/test/unit/backends/test_abstract.rb
+++ b/test/unit/backends/test_abstract.rb
@@ -40,7 +40,7 @@ module SSHKit
         )
       end
 
-      def test_test_method_creates_and_executes_command_with_false_raise_on_non_zero_exit
+      def test_test_creates_and_executes_command_with_false_raise_on_non_zero_exit
         backend = ExampleBackend.new do
           test '[ -d /some/file ]'
         end
@@ -49,6 +49,14 @@ module SSHKit
 
         assert_equal '[ -d /some/file ]', backend.executed_command.to_command
         assert_equal false, backend.executed_command.options[:raise_on_non_zero_exit], 'raise_on_non_zero_exit option'
+      end
+
+      def test_test_allows_to_override_verbosity
+        backend = ExampleBackend.new do
+          test 'echo output', {verbosity: Logger::INFO}
+        end
+        backend.run
+        assert_equal(backend.executed_command.options[:verbosity], Logger::INFO)
       end
 
       def test_capture_creates_and_executes_command_and_returns_stripped_output


### PR DESCRIPTION
Currently, the default params for those methods are applied differently, and I don't think that's intended. In the case of the #test method, the default params for `verbosity` and `raise_on_non_zero_exit` are overriding the provided by the user.
It makes impossible to have important #test calls show any output. At least without an ugly and non-thread safe `SSHKit.config.output_verbosity=Logger::DEBUG`.

So the proposed PR makes them consistent, using the approach from #capture and provides a test to cover that.
The overall change is pretty small.