### PR TITLE
Allow a Proc to be used as an interaction_handler

### DIFF
--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -234,7 +234,7 @@ module SSHKit
 
     def call_interaction_handler(stream_name, data, channel)
       interaction_handler = options[:interaction_handler]
-      interaction_handler = MappingInteractionHandler.new(interaction_handler) if interaction_handler.kind_of?(Hash)
+      interaction_handler = MappingInteractionHandler.new(interaction_handler) if interaction_handler.kind_of?(Hash) or interaction_handler.kind_of?(Proc)
       interaction_handler.on_data(self, stream_name, data, channel) if interaction_handler.respond_to?(:on_data)
     end
 

--- a/test/functional/backends/test_local.rb
+++ b/test/functional/backends/test_local.rb
@@ -99,6 +99,24 @@ module SSHKit
         end.run
         assert_equal("Enter Data\nCaptured SOME DATA", captured_command_result)
       end
+
+      def test_interaction_handler_with_proc
+        captured_command_result = nil
+        Local.new do
+          command = 'echo Enter Data; read the_data; echo Captured $the_data;'
+          captured_command_result = capture(command, interaction_handler:
+            lambda { |data|
+              case data
+              when "Enter Data\n"
+                "SOME DATA\n"
+              when "Captured SOME DATA\n"
+                nil
+              end
+            }
+          )
+        end.run
+        assert_equal("Enter Data\nCaptured SOME DATA", captured_command_result)
+      end
     end
   end
 end


### PR DESCRIPTION
According to the doc one can pass a Hash or a Proc as a
:interaction_handler option, but only Hashes were wrapped into a
MappingInteractionHandler.

Fix this and add a test.