### PR TITLE
Fix broken thread safety by widening critical section on ConnectionPool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ appear at the top.
 ## [Unreleased][]
 
   * Your contribution here!
+  * [#447](https://github.com/capistrano/sshkit/pull/447): Fix broken thread safety by widening critical section - [Takumasa Ochi](https://github.com/aeroastro)
 
 ## [1.18.0][] (2018-10-21)
 

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -118,9 +118,9 @@ class SSHKit::Backend::ConnectionPool
   # Update cache key with changed args to prevent cache miss
   def update_key_if_args_changed(cache, args)
     new_key = cache_key_for_connection_args(args)
-    return if cache.same_key?(new_key)
 
     caches.synchronize do
+      return if cache.same_key?(new_key)
       caches[new_key] = caches.delete(cache.key)
       cache.key = new_key
     end


### PR DESCRIPTION
## Bug Detail

Previously, the equality between cache.key and new_key
was evaluated outside the critical section of `caches.synchronize`.
When these 2 keys are evaluated as different by concurrent processes,
caches[cache.key] is deleted more than once and `nil` is assigned to
caches[new_key] after 1 thread passed critical section.

When `SSHKit::Backend::ConnectionPool#close_connections`
is invoked at the end of deployment, this pooled `nil` connection eventually
results in `NoMethodError` when `clear` is called.

https://github.com/capistrano/sshkit/blob/749337b70510e53cf6868b50d2882ac5fd4ebb40/lib/sshkit/backends/connection_pool.rb#L78

## How to Fix

This patch fix the issue by evaluating equality
inside the critical section of `caches.synchronize`.

## Test

In my environment this patch have fixed the problem.
Although I believe existent tests [here](https://github.com/capistrano/sshkit/blob/749337b70510e53cf6868b50d2882ac5fd4ebb40/test/unit/backends/test_connection_pool.rb) are sufficient to prove the validity of this patch,
I will consider adding test for simulating race condition if really required.