### PR TITLE
Fix Disabling of Connection Pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ appear at the top.
 
 ## [Unreleased][]
 
-  * Your contribution here!
+  * [#448](https://github.com/capistrano/sshkit/pull/448): Fix misbehaving connection eviction loop when disabling connection pooling - [Sebastian Cohnen](https://github.com/tisba)
 
 ## [1.18.1][] (2019-01-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ appear at the top.
 
 ## [Unreleased][]
 
+  * Your contribution here!
   * [#448](https://github.com/capistrano/sshkit/pull/448): Fix misbehaving connection eviction loop when disabling connection pooling - [Sebastian Cohnen](https://github.com/tisba)
 
 ## [1.18.1][] (2019-01-26)

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -46,7 +46,11 @@ class SSHKit::Backend::ConnectionPool
     @caches = {}
     @caches.extend(MonitorMixin)
     @timed_out_connections = Queue.new
-    Thread.new { run_eviction_loop }
+
+    # Spin up eviction loop only if caching is enabled
+    if cache_enabled?
+      Thread.new { run_eviction_loop }
+    end
   end
 
   # Creates a new connection or reuses a cached connection (if possible) and

--- a/lib/sshkit/backends/connection_pool.rb
+++ b/lib/sshkit/backends/connection_pool.rb
@@ -21,7 +21,7 @@ end
 
 # The ConnectionPool caches connections and allows them to be reused, so long as
 # the reuse happens within the `idle_timeout` period. Timed out connections are
-# closed, forcing a new connection to be used in that case.
+# eventually closed, forcing a new connection to be used in that case.
 #
 # Additionally, a background thread is started to check for abandoned
 # connections that have timed out without any attempt at being reused. These
@@ -137,7 +137,7 @@ class SSHKit::Backend::ConnectionPool
       process_deferred_close
 
       # Periodically sweep all Caches to evict stale connections
-      sleep([idle_timeout, 5].min)
+      sleep(5)
       caches.values.each(&:evict)
     end
   end


### PR DESCRIPTION
Fixes https://github.com/capistrano/sshkit/issues/438

The README currently states, that:

```ruby
SSHKit::Backend::Netssh.pool.idle_timeout = 0
```

will disable the cache and this can be used to mitigate potential problems from connection pooling. As described in #438 quite the opposite was the case. Connections were not cached, BUT the cache eviction loop was still started. With `idle_timeout = 0` the the eviction loop becomes a busy loop hogging one core at 100%.

This PR will skip the launch of the eviction loop (via `run_eviction_loop`) in case the cache is disabled. If the cache is disabled, there can't be any `timed_out_connections` because `silently_close_connection_later` is not used.

`find_cache` does not use `thread_safe_find_or_create_cache` if cache is disabled:

https://github.com/capistrano/sshkit/blob/ac181607508de1f1dbc8cb3b6df963ed343f5418/lib/sshkit/backends/connection_pool.rb#L98-L106

I'd like to get some guidance on how to test this (@leehambley maybe?).

## Further Suggestion

I also would like to propose that there is a maximum eviction frequency. The `idle_timeout` should not guarantee when idle connections are removed. Rather it should be considered "after `idle_timeout` sshkit will evict the connection eventually; never before". If you agree with this, we could simplify the `sleep` from this:

https://github.com/capistrano/sshkit/blob/ac181607508de1f1dbc8cb3b6df963ed343f5418/lib/sshkit/backends/connection_pool.rb#L129-L139

to

```ruby
sleep 5
```