### PR TITLE
Ensure UUID of command is shared when redacted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ appear at the top.
 ## [Unreleased][]
 
   * Your contribution here!
+* [#455](https://github.com/capistrano/sshkit/pull/455): Ensure UUID of commands are stable in logging - [@lazyatom](https://github.com/lazyatom)
 
 ## [1.18.2][] (2019-02-03)
 

--- a/lib/sshkit/command.rb
+++ b/lib/sshkit/command.rb
@@ -9,7 +9,7 @@ module SSHKit
 
     Failed = Class.new(SSHKit::StandardError)
 
-    attr_reader :command, :args, :options, :started_at, :started, :exit_status, :full_stdout, :full_stderr
+    attr_reader :command, :args, :options, :started_at, :started, :exit_status, :full_stdout, :full_stderr, :uuid
 
     # Initialize a new Command object
     #
@@ -25,6 +25,7 @@ module SSHKit
       @args    = args
       @options.symbolize_keys!
       @stdout, @stderr, @full_stdout, @full_stderr = String.new, String.new, String.new, String.new
+      @uuid = Digest::SHA1.hexdigest(SecureRandom.random_bytes(10))[0..7]
     end
 
     def complete?
@@ -39,10 +40,6 @@ module SSHKit
     def started=(new_started)
       @started_at = Time.now
       @started = new_started
-    end
-
-    def uuid
-      @uuid ||= Digest::SHA1.hexdigest(SecureRandom.random_bytes(10))[0..7]
     end
 
     def success?

--- a/test/unit/test_command.rb
+++ b/test/unit/test_command.rb
@@ -245,5 +245,10 @@ module SSHKit
       assert_equal "whoami exit status: 1\nwhoami stdout: Nothing written\nwhoami stderr: Nothing written\n", error.message
     end
 
+    def test_shares_same_uuid_before_and_after_redaction
+      command = Command.new(:whoami)
+      command_with_redaction = command.with_redaction
+      assert_equal command.uuid, command_with_redaction.uuid, "UUID should be stable before and after redaction"
+    end
   end
 end


### PR DESCRIPTION
In logging, the command UUID displayed in the "command start" phase was sometimes different to that displayed with the output of the command. This is because the backend can call `.with_redaction` on a command when logging the start, and this causes the command to be duplicated. However, if the `uuid` method hadn't been called before that point, the copy command would generate its own UUID, distinct from the original command.

This change avoids that by eagerly calculating the UUID when the command is created, so that any copied objects share the same UUID.

Fixes #454 