### PR TITLE
improve readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,29 +6,31 @@ more servers.
 [![Gem Version](https://badge.fury.io/rb/sshkit.svg)](https://rubygems.org/gems/sshkit)
 [![Build Status](https://travis-ci.org/capistrano/sshkit.svg?branch=master)](https://travis-ci.org/capistrano/sshkit)
 
-## How might it work?
+## Example
 
-The typical use-case looks something like this:
+ - Connect to 2 servers
+ - Execute commands as `deploy` user with `RAILS_ENV=production`
+ - Execute commands in serial (default is `:parallel`)
 
 ```ruby
 require 'sshkit'
 require 'sshkit/dsl'
 include SSHKit::DSL
 
-on %w{1.example.com 2.example.com}, in: :sequence, wait: 5 do |host|
+on ["1.example.com", "2.example.com"], in: :sequence do |host|
+  puts "Now executing on #{host}"
   within "/opt/sites/example.com" do
     as :deploy  do
-      with rails_env: :production do
-        rake   "assets:precompile"
-        runner "S3::Sync.notify"
-        execute :node, "socket_server.js"
+      with RAILS_ENV: 'production' do
+        execute :rake, "assets:precompile"
+        execute :rails, "runner", "S3::Sync.notify"
       end
     end
   end
 end
 ```
 
-You can find many other examples of how to use SSHKit over in [EXAMPLES.md](EXAMPLES.md).
+Many other examples are in [EXAMPLES.md](EXAMPLES.md).
 
 ## Basic usage
 


### PR DESCRIPTION
 - use more obvious `RAILS_ENV: :production` old one made me wonder "what does this even do, is this the ENV why is it not uppercase"
 - use more obvious `execute :rake`, misleading users into thinking all kinds of commands are prefdefined is bad, show them the general purpose tools
 - reduce example from 3->2 that's enough to show how it's done
 - remove `wait: 5` rarely used argument and users can just use builtin `sleep 5` if they want it
 - use simpler array syntax to not confuse

