### PR TITLE
Pin mocha at 1.9.x to fix CI failures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,10 +6,10 @@ AllCops:
   TargetRubyVersion: 2.0
 
 Lint/AmbiguousBlockAssociation:
-  Enabled:
-    false
+  Enabled: false
 Metrics/BlockLength:
   Exclude:
+    - "sshkit.gemspec"
     - "spec/**/*"
     - "lib/**/*.rake"
 Style/BarePercentLiterals:

--- a/examples/simple_connection.rb
+++ b/examples/simple_connection.rb
@@ -7,4 +7,3 @@ include SSHKit::DSL
 on [ENV.fetch("HOST")] do
   execute "echo hello"
 end
-

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rainbow', '~> 2.2.2')
   gem.add_development_dependency('rake')
   gem.add_development_dependency('rubocop', "~> 0.49.1")
-  gem.add_development_dependency('mocha')
+  gem.add_development_dependency('mocha', '~> 1.9.0')
 
   gem.add_development_dependency('bcrypt_pbkdf')
   gem.add_development_dependency('ed25519', '>= 1.2', '< 2.0')


### PR DESCRIPTION
Version 1.10 of the mocha gem was recently released, which is causing tests to fail in the master branch of SSHKit. Work around this for now by pinning our mocha dependency to `~> 1.9.0`.