### PR TITLE
Unpin mocha version and fix deprecation warnings for mocha v1.11.1

### DIFF
--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rainbow', '~> 2.2.2')
   gem.add_development_dependency('rake')
   gem.add_development_dependency('rubocop', "~> 0.49.1")
-  gem.add_development_dependency('mocha', '~> 1.9.0')
+  gem.add_development_dependency('mocha')
 
   gem.add_development_dependency('bcrypt_pbkdf')
   gem.add_development_dependency('ed25519', '>= 1.2', '< 2.0')

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,7 +3,7 @@ require 'bundler/setup'
 require 'tempfile'
 require 'minitest/autorun'
 require 'minitest/reporters'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'stringio'
 require 'json'
 

--- a/test/unit/formatters/test_pretty.rb
+++ b/test/unit/formatters/test_pretty.rb
@@ -115,7 +115,7 @@ module SSHKit
 
     def test_can_write_to_output_which_just_supports_append
       # Note output doesn't have to be an IO, it only needs to support <<
-      output = stub(:<<)
+      output = stub(:<< => nil)
       pretty = SSHKit::Formatter::Pretty.new(output)
       simulate_command_lifecycle(pretty)
     end


### PR DESCRIPTION
The undocumented behaviour that was changed in mocha v1.10.x has been reinstated in v1.11.1 albeit with deprecation warnings. Running the sshkit tests against mocha v1.11.1 (the latest version) allowed me to identify and fix two deprecation warnings, one of which was the cause of the problem in #479. I haven't attempted to run the functional tests locally, but hopefully your CI build will catch anything I've missed.