### PR TITLE
fix: test_upload_large_file should open file in binary file mode

### DIFF
--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -180,7 +180,7 @@ module SSHKit
         size      = 25
         fills     = SecureRandom.random_bytes(1024*1024)
         file_name = "/tmp/file-#{size}.txt"
-        File.open(file_name, 'w') do |f|
+        File.open(file_name, 'wb') do |f|
           (size).times {f.write(fills) }
         end
         file_contents = ""
@@ -188,7 +188,7 @@ module SSHKit
           upload!(file_name, file_name)
           file_contents = download!(file_name)
         end.run
-        assert_equal File.open(file_name).read, file_contents
+        assert_equal File.open(file_name, 'rb').read, file_contents
       end
 
       def test_upload_via_pathname


### PR DESCRIPTION
Hi @leehambley @mattbrictson 

Start working on https://github.com/capistrano/sshkit/issues/483. But I found that the local test dose not pass in my local environment (ruby version: 2.6.6 / macOS).

The `test_upload_large_file` failed to pass the test due to encoding issue.
```
...
205 tests, 3381 assertions, 0 failures, 0 errors, 0 skips
...
  test_upload_large_file                                          FAIL (22.06s)
        --- expected
        +++ actual
        @@ -1,3 +1,3 @@
        -# encoding: UTF-8
        - (snipped)
        -#    valid: false
        +# encoding: ASCII-8BIT
        +#    valid: true
        + (snipped)
...
25 tests, 35 assertions, 1 failures, 0 errors, 0 skips
```

After this fix:
```
205 tests, 3381 assertions, 0 failures, 0 errors, 0 skips
...
  test_upload_large_file                                          PASS (2.03s)
...
25 tests, 35 assertions, 0 failures, 0 errors, 0 skips
```