### PR TITLE
Fix closed connection in pool

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,11 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'hashicorp/precise64'
+  config.vm.provision "shell", inline: <<-SHELL
+  echo 'ClientAliveInterval 1' >> /etc/ssh/sshd_config
+  echo 'ClientAliveCountMax 1' >> /etc/ssh/sshd_config
+  service ssh restart
+  SHELL
 
   json_config_path = File.join("test", "boxes.json")
   list = File.open(json_config_path).read

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -212,6 +212,20 @@ module SSHKit
         end.run
         assert_equal("Enter Data\nCaptured SOME DATA", captured_command_result)
       end
+
+      def test_connection_pool_keepalive
+        # ensure we enable connection pool
+        SSHKit::Backend::Netssh.pool.idle_timeout = 10
+        Netssh.new(a_host) do |_host|
+          test :false
+        end.run
+        sleep 2.5
+        captured_command_result = nil
+        Netssh.new(a_host) do |_host|
+          captured_command_result = capture(:echo, 'some_value')
+        end.run
+        assert_equal "some_value", captured_command_result
+      end
     end
 
   end


### PR DESCRIPTION
Hi @leehambley 

This is the PR that aims to partially solve https://github.com/capistrano/sshkit/issues/483.
Sorry for the delay.

The change will do a simple polling (`process(0)`) to check if the connection is still alive before we reuse it. If the connection is closed by remote, the polling will get `<IOError: closed stream>` which will be caught and consider the connection is already closed. It partially fixes https://github.com/capistrano/sshkit/issues/483 since when the keepalive check fails and remote host closes the connection, the connection won't be reused.

However, it will not completely fix the issue because the keepalive packet should be responded by `ssh-kit/net-ssh` but it doesn't. This could be fixed by introducing another thread that keep pooling connections in pool so that `net-ssh` will reply to keepalive packets. But I'm reluctant to do so since it would introduce new threads to maintain and complexity such as interval settings. I would like to fix the closed connection reuse issue first and leave the complete fix to others if it's needed.

By the way, you can check out  https://github.com/capistrano/sshkit/commit/48d6ff39155e76a64b72c3afa710faf8604d731c and run the test then it will reproduce the https://github.com/capistrano/sshkit/issues/483.