### PR TITLE
Add latest rubies to CI, including 3.0; drop rubinius CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: ruby
 rvm:
+  - 3.0
+  - 2.7
+  - 2.6
   - 2.5
   - 2.4
   - 2.3
@@ -8,7 +11,7 @@ rvm:
   - 2.0
 branches:
   only:
-  - master
+    - master
 matrix:
   include:
     # Run Danger only once, on 2.5

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-platforms :rbx do
-  gem 'rubysl', '~> 2.0'
-  gem 'json'
-end
-
 # public_suffix 3+ requires ruby 2.1+
 if Gem::Requirement.new('< 2.1').satisfied_by?(Gem::Version.new(RUBY_VERSION))
   gem 'public_suffix', '< 3'


### PR DESCRIPTION
This PR makes some minor modifications to our CI setup:

1. Add Ruby 2.6, 2.7, 3.0 to Travis CI.
2. Drop special gems from our Gemfile that supported Rubinius in CI. We haven't actually run Rubinius in CI since 2014, so these gems are definitely not needed now. One of the gems, `rubysl`, was preventing CI from working with Ruby 3.0.