### PR TITLE
chore: Included githubactions in the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,8 @@ updates:
   - dependency-name: rubocop
     versions:
     - "> 0.49.1"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule: 
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule: 
       interval: monthly
-    open-pull-requests-limit: 10
+  open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,5 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule: 
-      interval: monthly
+    interval: monthly
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
   - dependency-name: rubocop
     versions:
     - "> 0.49.1"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: 
+      interval: monthly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This should help with keeping the GitHub actions updated on new releases. This will also help with keeping it secure.

Dependabot helps in keeping the supply chain secure https://docs.github.com/en/code-security/dependabot

GitHub actions up to date https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

https://github.com/ossf/scorecard/blob/main/docs/checks.md#dependency-update-tool
Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
