### PR TITLE
Fix test by `require 'set'`

### DIFF
--- a/lib/sshkit/deprecation_logger.rb
+++ b/lib/sshkit/deprecation_logger.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module SSHKit
   class DeprecationLogger
     def initialize(out)


### PR DESCRIPTION
There are some tests fail with messages below.
```
SSHKit::TestConfiguration
  test_nil_deprecation_output                                    ERROR (0.00s)
Minitest::UnexpectedError:         NameError: uninitialized constant SSHKit::DeprecationLogger::Set
        Did you mean?  Net
            /Users/colorbox/.ghq/github.com/capistrano/sshkit/lib/sshkit/deprecation_logger.rb:5:in `initialize'
            /Users/colorbox/.ghq/github.com/capistrano/sshkit/lib/sshkit/configuration.rb:21:in `new'
            /Users/colorbox/.ghq/github.com/capistrano/sshkit/lib/sshkit/configuration.rb:21:in `deprecation_output='
            /Users/colorbox/.ghq/github.com/capistrano/sshkit/test/unit/test_configuration.rb:25:in `test_nil_deprecation_output'
```

This PR add `require 'set'` to avoid raise NameError.