### PR TITLE
Add functional test with vagrant on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,31 @@ jobs:
           bundler-cache: true
       - name: Run rubocop
         run: bundle exec rake lint
+
+  functional:
+    runs-on: macos-10.15
+    strategy:
+      matrix:
+        ruby: [ "2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head" ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Cache Vagrant boxes
+        uses: actions/cache@v2
+        with:
+          path: ~/.vagrant.d/boxes
+          key: ${{ runner.os }}-vagrant-${{ hashFiles('Vagrantfile') }}
+          restore-keys: |
+            ${{ runner.os }}-vagrant-
+
+      - name: Run vagrant up
+        run: vagrant up
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run functional tests
+        run: bundle exec rake test:functional

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,8 +3,8 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'hashicorp/precise64'
   config.vm.provision "shell", inline: <<-SHELL
-  echo 'ClientAliveInterval 1' >> /etc/ssh/sshd_config
-  echo 'ClientAliveCountMax 1' >> /etc/ssh/sshd_config
+  echo 'ClientAliveInterval 3' >> /etc/ssh/sshd_config
+  echo 'ClientAliveCountMax 3' >> /etc/ssh/sshd_config
   service ssh restart
   SHELL
 


### PR DESCRIPTION
This PR adds functional test on CI withs `vagrant up` on GitHub Actions. Some VM settings updated for keep alive connection for `test_upload_large_file`.

refs: https://github.com/jonashackt/vagrant-github-actions