### PR TITLE
CI: Use newer Vagrant box to address timeout issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.vagrant.d/boxes
-          key: ${{ runner.os }}-vagrant-${{ hashFiles('Vagrantfile') }}
+          key: ${{ runner.os }}-vagrant-v2-${{ hashFiles('Vagrantfile') }}
           restore-keys: |
-            ${{ runner.os }}-vagrant-
+            ${{ runner.os }}-vagrant-v2-
 
       - name: Run vagrant up
         run: vagrant up

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,11 +1,14 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'hashicorp/precise64'
-  config.vm.boot_timeout = 480 # seconds
+  config.vm.box = 'bento/ubuntu-22.10'
+
+  config.vm.boot_timeout = 600 # seconds
+  config.ssh.insert_key = false
   config.vm.provision "shell", inline: <<-SHELL
   echo 'ClientAliveInterval 3' >> /etc/ssh/sshd_config
   echo 'ClientAliveCountMax 3' >> /etc/ssh/sshd_config
+  echo 'MaxAuthTries 6' >> /etc/ssh/sshd_config
   service ssh restart
   SHELL
 

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -75,14 +75,14 @@ module SSHKit
 
       def test_group_netssh
         Netssh.new(a_host) do
-          as user: :root, group: :admin do
+          as user: :root, group: :root do
            execute :touch, 'restart.txt'
           end
         end.run
         command_lines = @output.lines.select { |line| line.start_with?('Command:') }
         assert_equal [
           "Command: if ! sudo -u root whoami > /dev/null; then echo \"You cannot switch to user 'root' using sudo, please check the sudoers file\" 1>&2; false; fi\n",
-          "Command: sudo -u root -- sh -c sg\\ admin\\ -c\\ /usr/bin/env\\\\\\ touch\\\\\\ restart.txt\n"
+          "Command: sudo -u root -- sh -c sg\\ root\\ -c\\ /usr/bin/env\\\\\\ touch\\\\\\ restart.txt\n"
         ], command_lines
       end
 


### PR DESCRIPTION
We were using an extremely old Vagrant box for functional tests. Booting this Vagrant box would often fail with timeout errors in CI. This PR is attempt to fix the problem with the following changes:

1. Upgrade the box to [bento/ubuntu-22.10](https://app.vagrantup.com/bento/boxes/ubuntu-22.10)
2. Increase the timeout to 10 minutes
3. Rotate the GitHub Actions cache key so that we are using a fresh, empty cache for Vagrant

I also increased `MaxAuthTries` to fix authentication failures I was seeing when trying to run functional tests locally.