### PR TITLE
Re-enable functional tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,22 +75,9 @@ jobs:
     env:
       VAGRANT_DISABLE_VBOXSYMLINKCREATE: "1"
     strategy:
+      max-parallel: 1
       matrix:
-        ruby:
-          [
-            "2.0",
-            "2.1",
-            "2.2",
-            "2.3",
-            "2.4",
-            "2.5",
-            "2.6",
-            "2.7",
-            "3.0",
-            "3.1",
-            "3.2",
-            "head",
-          ]
+        ruby: ["2.0", "3.3"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,3 +69,59 @@ jobs:
           bundler-cache: true
       - name: Run rubocop
         run: bundle exec rake lint
+
+  functional:
+    runs-on: macos-latest
+    env:
+      VAGRANT_DISABLE_VBOXSYMLINKCREATE: "1"
+    strategy:
+      matrix:
+        ruby:
+          [
+            "2.0",
+            "2.1",
+            "2.2",
+            "2.3",
+            "2.4",
+            "2.5",
+            "2.6",
+            "2.7",
+            "3.0",
+            "3.1",
+            "3.2",
+            "head",
+          ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache Vagrant boxes
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes
+          key: ${{ runner.os }}-vagrant-v2-${{ hashFiles('Vagrantfile') }}
+          restore-keys: |
+            ${{ runner.os }}-vagrant-v2-
+
+      - name: Run vagrant up
+        run: vagrant up
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run functional tests
+        run: bundle exec rake test:functional
+
+  functional-all:
+    runs-on: ubuntu-latest
+    needs: [functional]
+    if: always()
+    steps:
+      - name: All tests ok
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some tests failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         run: bundle exec rake lint
 
   functional:
-    runs-on: macos-latest
+    runs-on: macos-latest-xl
     env:
       VAGRANT_DISABLE_VBOXSYMLINKCREATE: "1"
     strategy:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'bento/ubuntu-22.10'
   config.vm.boot_timeout = 600 # seconds
   config.vm.provider 'virtualbox' do |vb|
-    vb.memory = 1024
+    vb.memory = 2048
     vb.cpus = 1
 
     # https://github.com/hashicorp/vagrant/issues/11777#issuecomment-661076612

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,11 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'bento/ubuntu-22.10'
-
   config.vm.boot_timeout = 600 # seconds
+  config.vm.provider 'virtualbox' do |vb|
+    vb.memory = 1024
+    vb.cpus = 1
+  end
   config.ssh.insert_key = false
   config.vm.provision "shell", inline: <<-SHELL
   echo 'ClientAliveInterval 3' >> /etc/ssh/sshd_config

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider 'virtualbox' do |vb|
     vb.memory = 1024
     vb.cpus = 1
+
+    # https://github.com/hashicorp/vagrant/issues/11777#issuecomment-661076612
+    vb.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+    vb.customize ["modifyvm", :id, "--uartmode1", "file", File::NULL]
   end
   config.ssh.insert_key = false
   config.vm.provision "shell", inline: <<-SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,12 +4,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'bento/ubuntu-22.10'
   config.vm.boot_timeout = 600 # seconds
   config.vm.provider 'virtualbox' do |vb|
-    vb.memory = 2048
+    vb.memory = 1024
     vb.cpus = 1
-
-    # https://github.com/hashicorp/vagrant/issues/11777#issuecomment-661076612
-    vb.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
-    vb.customize ["modifyvm", :id, "--uartmode1", "file", File::NULL]
   end
   config.ssh.insert_key = false
   config.vm.provision "shell", inline: <<-SHELL

--- a/lib/sshkit/backends/netssh/sftp_transfer.rb
+++ b/lib/sshkit/backends/netssh/sftp_transfer.rb
@@ -29,7 +29,7 @@ module SSHKit
         end
 
         def on_get(download, entry, offset, data)
-          entry.size ||= download.sftp.file.open(entry.remote, &:size)
+          entry.size ||= download.sftp.file.open(entry.remote) { |file| file.stat.size }
           summarizer.call(nil, entry.remote, offset + data.bytesize, entry.size)
         end
 

--- a/test/boxes.json
+++ b/test/boxes.json
@@ -5,13 +5,5 @@
     "user": "vagrant",
     "password": "vagrant",
     "hostname": "localhost"
-  },
-  {
-    "name": "two",
-    "port": 3002
-  },
-  {
-    "name": "three",
-    "port": 3003
   }
 ]

--- a/test/functional/test_ssh_server_comes_up_for_functional_tests.rb
+++ b/test/functional/test_ssh_server_comes_up_for_functional_tests.rb
@@ -15,7 +15,7 @@ module SSHKit
     def test_creating_a_user_gives_us_back_his_private_key_as_a_string
       skip 'It is not safe to create an user for non vagrant envs' unless VagrantWrapper.running?
       keys = create_user_with_key(:peter)
-      assert_equal [:one, :two, :three], keys.keys
+      assert_equal [:one], keys.keys
       assert keys.values.all?
     end
 


### PR DESCRIPTION
Functional tests were disabled in CI in #523 due to GitHub Actions issues.

This PR plans to reenable functional tests in CI once those issues are resolved. It also cargo-cults some Vagrantfile improvements from https://github.com/fastapi-mvc/example/blob/6b29b3fe3dc9004aa7492c4d2ecd569fdf7e3ec3/Vagrantfile