### PR TITLE
Allow SFTP to be used for upload!/download! instead of SCP

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -162,6 +162,23 @@ end
 In this case the `recursive: true` option mirrors the same options which are
 available to [`Net::{SCP,SFTP}`](http://net-ssh.github.io/net-scp/).
 
+## Set the upload/download method (SCP or SFTP).
+
+SSHKit can use SCP or SFTP for file transfers. The default is SCP, but this can be changed to SFTP per host:
+
+```ruby
+host = SSHKit::Host.new('user@example.com')
+host.transfer_method = :sftp
+```
+
+or globally:
+
+```ruby
+SSHKit::Backend::Netssh.configure do |ssh|
+  ssh.transfer_method = :sftp
+end
+```
+
 ## Setting global SSH options
 
 Setting global SSH options, these will be overwritten by options set on the

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ you can pass the `strip: false` option: `capture(:ls, '-l', strip: false)`
 ### Transferring files
 
 All backends also support the `upload!` and `download!` methods for transferring files.
-For the remote backend, the file is transferred with scp.
+For the remote backend, the file is transferred with scp by default, but sftp is also
+supported. See [EXAMPLES.md](EXAMPLES.md) for details.
 
 ```ruby
 on '1.example.com' do

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -200,10 +200,17 @@ module SSHKit
       end
 
       def with_transfer(summarizer)
-        require_relative "netssh/scp_transfer"
+        transfer_method = host.transfer_method || self.class.config.transfer_method
+        transfer_class = if transfer_method == :sftp
+                           require_relative "netssh/sftp_transfer"
+                           SftpTransfer
+                         else
+                           require_relative "netssh/scp_transfer"
+                           ScpTransfer
+                         end
 
         with_ssh do |ssh|
-          yield(ScpTransfer.new(ssh, summarizer))
+          yield(transfer_class.new(ssh, summarizer))
         end
       end
     end

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -22,9 +22,26 @@ module SSHKit
   module Backend
 
     class Netssh < Abstract
+      def self.assert_valid_transfer_method!(method)
+        return if [nil, :scp, :sftp].include?(method)
+
+        raise ArgumentError, "#{method.inspect} is not a valid transfer method. Supported methods are :scp, :sftp."
+      end
+
       class Configuration
         attr_accessor :connection_timeout, :pty
+        attr_reader :transfer_method
         attr_writer :ssh_options
+
+        def initialize
+          self.transfer_method = :scp
+        end
+
+        def transfer_method=(method)
+          Netssh.assert_valid_transfer_method!(method)
+
+          @transfer_method = method
+        end
 
         def ssh_options
           default_options.merge(@ssh_options ||= {})

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -23,7 +23,7 @@ module SSHKit
 
     class Netssh < Abstract
       def self.assert_valid_transfer_method!(method)
-        return if [nil, :scp, :sftp].include?(method)
+        return if [:scp, :sftp].include?(method)
 
         raise ArgumentError, "#{method.inspect} is not a valid transfer method. Supported methods are :scp, :sftp."
       end

--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -104,7 +104,7 @@ module SSHKit
         last_percentage = nil
         proc do |_ch, name, transferred, total|
           percentage = (transferred.to_f * 100 / total.to_f)
-          unless percentage.nan?
+          unless percentage.nan? || percentage.infinite?
             message = "#{action} #{name} #{percentage.round(2)}%"
             percentage_r = (percentage / log_percent).truncate * log_percent
             if percentage_r > 0 && (last_name != name || last_percentage != percentage_r)

--- a/lib/sshkit/backends/netssh/scp_transfer.rb
+++ b/lib/sshkit/backends/netssh/scp_transfer.rb
@@ -1,0 +1,26 @@
+require "net/scp"
+
+module SSHKit
+  module Backend
+    class Netssh < Abstract
+      class ScpTransfer
+        def initialize(ssh, summarizer)
+          @ssh = ssh
+          @summarizer = summarizer
+        end
+
+        def upload!(local, remote, options)
+          ssh.scp.upload!(local, remote, options, &summarizer)
+        end
+
+        def download!(remote, local, options)
+          ssh.scp.download!(remote, local, options, &summarizer)
+        end
+
+        private
+
+        attr_reader :ssh, :summarizer
+      end
+    end
+  end
+end

--- a/lib/sshkit/backends/netssh/sftp_transfer.rb
+++ b/lib/sshkit/backends/netssh/sftp_transfer.rb
@@ -1,0 +1,46 @@
+require "net/sftp"
+
+module SSHKit
+  module Backend
+    class Netssh < Abstract
+      class SftpTransfer
+        def initialize(ssh, summarizer)
+          @ssh = ssh
+          @summarizer = summarizer
+        end
+
+        def upload!(local, remote, options)
+          options = { progress: self }.merge(options || {})
+          ssh.sftp.connect!
+          ssh.sftp.upload!(local, remote, options)
+        ensure
+          ssh.sftp.close_channel
+        end
+
+        def download!(remote, local, options)
+          options = { progress: self }.merge(options || {})
+          destination = local ? local : StringIO.new.tap { |io| io.set_encoding('BINARY') }
+
+          ssh.sftp.connect!
+          ssh.sftp.download!(remote, destination, options)
+          local ? true : destination.string
+        ensure
+          ssh.sftp.close_channel
+        end
+
+        def on_get(download, entry, offset, data)
+          entry.size ||= download.sftp.file.open(entry.remote, &:size)
+          summarizer.call(nil, entry.remote, offset + data.bytesize, entry.size)
+        end
+
+        def on_put(_upload, file, offset, data)
+          summarizer.call(nil, file.local, offset + data.bytesize, file.size)
+        end
+
+        private
+
+        attr_reader :ssh, :summarizer
+      end
+    end
+  end
+end

--- a/lib/sshkit/host.rb
+++ b/lib/sshkit/host.rb
@@ -7,6 +7,7 @@ module SSHKit
   class Host
 
     attr_accessor :password, :hostname, :port, :user, :ssh_options
+    attr_reader :transfer_method
 
     def key=(new_key)
       @keys = [new_key]
@@ -39,6 +40,12 @@ module SSHKit
           end
         end
       end
+    end
+
+    def transfer_method=(method)
+      Backend::Netssh.assert_valid_transfer_method!(method)
+
+      @transfer_method = method
     end
 
     def local?

--- a/lib/sshkit/host.rb
+++ b/lib/sshkit/host.rb
@@ -43,7 +43,7 @@ module SSHKit
     end
 
     def transfer_method=(method)
-      Backend::Netssh.assert_valid_transfer_method!(method)
+      Backend::Netssh.assert_valid_transfer_method!(method) unless method.nil?
 
       @transfer_method = method
     end

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')
+  gem.add_runtime_dependency('net-sftp', '>= 2.1.2')
 
   gem.add_development_dependency('danger')
   gem.add_development_dependency('minitest', '>= 5.0.0')

--- a/test/functional/backends/netssh_transfer_tests.rb
+++ b/test/functional/backends/netssh_transfer_tests.rb
@@ -1,0 +1,83 @@
+require 'securerandom'
+
+module SSHKit
+  module Backend
+    module NetsshTransferTests
+      def setup
+        super
+        @output = String.new
+        SSHKit.config.output_verbosity = :debug
+        SSHKit.config.output = SSHKit::Formatter::SimpleText.new(@output)
+      end
+
+      def a_host
+        VagrantWrapper.hosts['one']
+      end
+
+      def test_upload_and_then_capture_file_contents
+        actual_file_contents = ""
+        file_name = File.join("/tmp", SecureRandom.uuid)
+        File.open file_name, 'w+' do |f|
+          f.write "Some Content\nWith a newline and trailing spaces    \n "
+        end
+        Netssh.new(a_host) do
+          upload!(file_name, file_name)
+          actual_file_contents = capture(:cat, file_name, strip: false)
+        end.run
+        assert_equal "Some Content\nWith a newline and trailing spaces    \n ", actual_file_contents
+      end
+
+      def test_upload_within
+        file_name = SecureRandom.uuid
+        file_contents = "Some Content"
+        dir_name = SecureRandom.uuid
+        actual_file_contents = ""
+        Netssh.new(a_host) do |_host|
+          within("/tmp") do
+            execute :mkdir, "-p", dir_name
+            within(dir_name) do
+              upload!(StringIO.new(file_contents), file_name)
+            end
+          end
+          actual_file_contents = capture(:cat, "/tmp/#{dir_name}/#{file_name}", strip: false)
+        end.run
+        assert_equal file_contents, actual_file_contents
+      end
+
+      def test_upload_string_io
+        file_contents = ""
+        Netssh.new(a_host) do |_host|
+          file_name = File.join("/tmp", SecureRandom.uuid)
+          upload!(StringIO.new('example_io'), file_name)
+          file_contents = download!(file_name)
+        end.run
+        assert_equal "example_io", file_contents
+      end
+
+      def test_upload_large_file
+        size      = 25
+        fills     = SecureRandom.random_bytes(1024*1024)
+        file_name = "/tmp/file-#{size}.txt"
+        File.open(file_name, 'wb') do |f|
+          (size).times {f.write(fills) }
+        end
+        file_contents = ""
+        Netssh.new(a_host) do
+          upload!(file_name, file_name)
+          file_contents = download!(file_name)
+        end.run
+        assert_equal File.open(file_name, 'rb').read, file_contents
+      end
+
+      def test_upload_via_pathname
+        file_contents = ""
+        Netssh.new(a_host) do |_host|
+          file_name = Pathname.new(File.join("/tmp", SecureRandom.uuid))
+          upload!(StringIO.new('example_io'), file_name)
+          file_contents = download!(file_name)
+        end.run
+        assert_equal "example_io", file_contents
+      end
+    end
+  end
+end

--- a/test/functional/backends/test_netssh.rb
+++ b/test/functional/backends/test_netssh.rb
@@ -1,5 +1,4 @@
 require 'helper'
-require 'securerandom'
 require 'benchmark'
 
 module SSHKit
@@ -134,71 +133,6 @@ module SSHKit
         Netssh.new(a_host) do |_host|
           test :false
         end.run
-      end
-
-      def test_upload_and_then_capture_file_contents
-        actual_file_contents = ""
-        file_name = File.join("/tmp", SecureRandom.uuid)
-        File.open file_name, 'w+' do |f|
-          f.write "Some Content\nWith a newline and trailing spaces    \n "
-        end
-        Netssh.new(a_host) do
-          upload!(file_name, file_name)
-          actual_file_contents = capture(:cat, file_name, strip: false)
-        end.run
-        assert_equal "Some Content\nWith a newline and trailing spaces    \n ", actual_file_contents
-      end
-
-      def test_upload_within
-        file_name = SecureRandom.uuid
-        file_contents = "Some Content"
-        dir_name = SecureRandom.uuid
-        actual_file_contents = ""
-        Netssh.new(a_host) do |_host|
-          within("/tmp") do
-            execute :mkdir, "-p", dir_name
-            within(dir_name) do
-              upload!(StringIO.new(file_contents), file_name)
-            end
-          end
-          actual_file_contents = capture(:cat, "/tmp/#{dir_name}/#{file_name}", strip: false)
-        end.run
-        assert_equal file_contents, actual_file_contents
-      end
-
-      def test_upload_string_io
-        file_contents = ""
-        Netssh.new(a_host) do |_host|
-          file_name = File.join("/tmp", SecureRandom.uuid)
-          upload!(StringIO.new('example_io'), file_name)
-          file_contents = download!(file_name)
-        end.run
-        assert_equal "example_io", file_contents
-      end
-
-      def test_upload_large_file
-        size      = 25
-        fills     = SecureRandom.random_bytes(1024*1024)
-        file_name = "/tmp/file-#{size}.txt"
-        File.open(file_name, 'wb') do |f|
-          (size).times {f.write(fills) }
-        end
-        file_contents = ""
-        Netssh.new(a_host) do
-          upload!(file_name, file_name)
-          file_contents = download!(file_name)
-        end.run
-        assert_equal File.open(file_name, 'rb').read, file_contents
-      end
-
-      def test_upload_via_pathname
-        file_contents = ""
-        Netssh.new(a_host) do |_host|
-          file_name = Pathname.new(File.join("/tmp", SecureRandom.uuid))
-          upload!(StringIO.new('example_io'), file_name)
-          file_contents = download!(file_name)
-        end.run
-        assert_equal "example_io", file_contents
       end
 
       def test_interaction_handler

--- a/test/functional/backends/test_netssh_scp.rb
+++ b/test/functional/backends/test_netssh_scp.rb
@@ -12,6 +12,12 @@ module SSHKit
           ssh.transfer_method = :scp
         end
       end
+
+      def test_scp_implementation_is_used
+        Netssh.new(a_host).send(:with_transfer, nil) do |transfer|
+          assert_instance_of Netssh::ScpTransfer, transfer
+        end
+      end
     end
   end
 end

--- a/test/functional/backends/test_netssh_scp.rb
+++ b/test/functional/backends/test_netssh_scp.rb
@@ -1,0 +1,17 @@
+require 'helper'
+require_relative 'netssh_transfer_tests'
+
+module SSHKit
+  module Backend
+    class TestNetsshScp < FunctionalTest
+      include NetsshTransferTests
+
+      def setup
+        super
+        SSHKit::Backend::Netssh.configure do |ssh|
+          ssh.transfer_method = :scp
+        end
+      end
+    end
+  end
+end

--- a/test/functional/backends/test_netssh_sftp.rb
+++ b/test/functional/backends/test_netssh_sftp.rb
@@ -12,6 +12,12 @@ module SSHKit
           ssh.transfer_method = :sftp
         end
       end
+
+      def test_sftp_implementation_is_used
+        Netssh.new(a_host).send(:with_transfer, nil) do |transfer|
+          assert_instance_of Netssh::SftpTransfer, transfer
+        end
+      end
     end
   end
 end

--- a/test/functional/backends/test_netssh_sftp.rb
+++ b/test/functional/backends/test_netssh_sftp.rb
@@ -1,0 +1,17 @@
+require 'helper'
+require_relative 'netssh_transfer_tests'
+
+module SSHKit
+  module Backend
+    class TestNetsshSftp < FunctionalTest
+      include NetsshTransferTests
+
+      def setup
+        super
+        SSHKit::Backend::Netssh.configure do |ssh|
+          ssh.transfer_method = :sftp
+        end
+      end
+    end
+  end
+end

--- a/test/unit/backends/test_netssh.rb
+++ b/test/unit/backends/test_netssh.rb
@@ -5,6 +5,12 @@ module SSHKit
   module Backend
     class TestNetssh < UnitTest
 
+      def teardown
+        super
+        # Reset config to defaults after each test
+        backend.instance_variable_set :@config, nil
+      end
+
       def backend
         @backend ||= Netssh
       end
@@ -39,6 +45,26 @@ module SSHKit
         end
 
         assert_match ":nope is not a valid transfer method", error.message
+      end
+
+      def test_transfer_method_defaults_to_scp
+        assert_equal :scp, backend.config.transfer_method
+      end
+
+      def test_host_can_override_transfer_method
+        backend.configure do |ssh|
+          ssh.transfer_method = :scp
+        end
+
+        host = Host.new("fake")
+        host.transfer_method = :sftp
+
+        netssh = backend.new(host)
+        netssh.stubs(:with_ssh).yields(nil)
+
+        netssh.send(:with_transfer, nil) do |transfer|
+          assert_instance_of Netssh::SftpTransfer, transfer
+        end
       end
 
       def test_netssh_ext

--- a/test/unit/backends/test_netssh.rb
+++ b/test/unit/backends/test_netssh.rb
@@ -47,6 +47,16 @@ module SSHKit
         assert_match ":nope is not a valid transfer method", error.message
       end
 
+      def test_transfer_method_does_not_allow_nil
+        error = assert_raises ArgumentError do
+          backend.configure do |ssh|
+            ssh.transfer_method = nil
+          end
+        end
+
+        assert_match "nil is not a valid transfer method", error.message
+      end
+
       def test_transfer_method_defaults_to_scp
         assert_equal :scp, backend.config.transfer_method
       end

--- a/test/unit/backends/test_netssh.rb
+++ b/test/unit/backends/test_netssh.rb
@@ -13,6 +13,7 @@ module SSHKit
         backend.configure do |ssh|
           ssh.pty = true
           ssh.connection_timeout = 30
+          ssh.transfer_method = :sftp
           ssh.ssh_options = {
             keys: %w(/home/user/.ssh/id_rsa),
             forward_agent: false,
@@ -21,12 +22,23 @@ module SSHKit
         end
 
         assert_equal 30, backend.config.connection_timeout
+        assert_equal :sftp, backend.config.transfer_method
         assert_equal true, backend.config.pty
 
         assert_equal %w(/home/user/.ssh/id_rsa),  backend.config.ssh_options[:keys]
         assert_equal false,                       backend.config.ssh_options[:forward_agent]
         assert_equal %w(publickey password),      backend.config.ssh_options[:auth_methods]
         assert_instance_of backend::KnownHosts,   backend.config.ssh_options[:known_hosts]
+      end
+
+      def test_transfer_method_prohibits_invalid_values
+        error = assert_raises ArgumentError do
+          backend.configure do |ssh|
+            ssh.transfer_method = :nope
+          end
+        end
+
+        assert_match ":nope is not a valid transfer method", error.message
       end
 
       def test_netssh_ext

--- a/test/unit/test_host.rb
+++ b/test/unit/test_host.rb
@@ -142,6 +142,33 @@ module SSHKit
       end
     end
 
+    def test_transfer_method_defaults_to_nil
+      host = Host.new 'example.com'
+      assert_nil host.transfer_method
+    end
+
+    def test_transfer_method_can_be_configured
+      host = Host.new 'example.com'
+
+      host.transfer_method = :scp
+      assert_equal :scp, host.transfer_method
+
+      host.transfer_method = :sftp
+      assert_equal :sftp, host.transfer_method
+
+      host.transfer_method = nil
+      assert_nil host.transfer_method
+    end
+
+    def test_transfer_method_prohibits_invalid_values
+      host = Host.new 'example.com'
+
+      error = assert_raises ArgumentError do
+        host.transfer_method = :nope
+      end
+
+      assert_match ":nope is not a valid transfer method", error.message
+    end
   end
 
 end


### PR DESCRIPTION
SSHKit can now use SFTP for file transfers. The default is still SCP, but this can be changed to SFTP per host:

```ruby
host = SSHKit::Host.new('user@example.com')
host.transfer_method = :sftp
```

or globally:

```ruby
SSHKit::Backend::Netssh.configure do |ssh|
  ssh.transfer_method = :sftp
end
```

Fixes #15 