### PR TITLE
Add mutex_m dependency to fix Ruby 3.3 warning

### DIFF
--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SSHKit::VERSION
 
+  gem.add_runtime_dependency('mutex_m')
   gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')
 


### PR DESCRIPTION
This fixes the following warning when using Capistrano on Ruby 3.3:

> sshkit/backends/netssh.rb:3: warning: mutex_m was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add mutex_m to your Gemfile or gemspec.