### PR TITLE
Support older net-sftp API for Ruby 2.0

### DIFF
--- a/lib/sshkit/backends/netssh/sftp_transfer.rb
+++ b/lib/sshkit/backends/netssh/sftp_transfer.rb
@@ -29,7 +29,7 @@ module SSHKit
         end
 
         def on_get(download, entry, offset, data)
-          entry.size ||= download.sftp.file.open(entry.remote, &:size)
+          entry.size ||= download.sftp.file.open(entry.remote) { |file| file.stat.size }
           summarizer.call(nil, entry.remote, offset + data.bytesize, entry.size)
         end
 


### PR DESCRIPTION
Old Rubies such as Ruby 2.0 resolve a version of net-sftp that does not have the `File#size` convenience method. To support these older versions, use the lower level `File#stat`, which works for versions of net-sftp all the way back to 2.1.2.

This fixes a `NoMethodError` when SFTP is used via sshkit on Ruby 2.0.

I was able to confirm this with this successful CI job: https://github.com/capistrano/sshkit/actions/runs/7373383846/job/20062512939

Fixes #528 