### PR TITLE
Explicitly require base64 to fix missing constant with net-ssh 7.2.2+

### DIFF
--- a/lib/sshkit/backends/netssh/known_hosts.rb
+++ b/lib/sshkit/backends/netssh/known_hosts.rb
@@ -1,3 +1,5 @@
+require "base64"
+
 module SSHKit
 
   module Backend

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SSHKit::VERSION
 
+  gem.add_runtime_dependency('base64')
   gem.add_runtime_dependency('mutex_m')
   gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = SSHKit::VERSION
 
-  gem.add_runtime_dependency('base64')
+  gem.add_runtime_dependency('base64') if RUBY_VERSION >= "2.4"
   gem.add_runtime_dependency('mutex_m')
   gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')


### PR DESCRIPTION
sshkit needs `Base64` for its implementation of the known hosts file parser.

Before, we were relying on net-ssh to load Base64 for us. But starting in net-ssh 7.2.2 (which was yanked), net-ssh no longer depends on the base64 gem. That means sshkit can no longer assume it will be present and loaded.

This PR fixes compatibility with net-ssh 7.2.2+ by doing the following:

- `require "base64"` to ensure the `Base64` constant is defined
- Add `base64` as a runtime dependency so that the library is guaranteed to be present

Fixes #531 