### PR TITLE
Fix failing tests on ruby head

### DIFF
--- a/test/unit/backends/test_abstract.rb
+++ b/test/unit/backends/test_abstract.rb
@@ -124,7 +124,7 @@ module SSHKit
         assert_equal 2, lines.length
 
         assert_equal("[Deprecated] The background method is deprecated. Blame badly behaved pseudo-daemons!\n", lines[0])
-        assert_match(/    \(Called from.*test_abstract.rb:\d+:in `block in test_background_logs_deprecation_warnings'\)\n/, lines[1])
+        assert_match(/    \(Called from.*test_abstract.rb:\d+:in .block in .*test_background_logs_deprecation_warnings.\)\n/, lines[1])
       end
 
       def test_calling_abstract_with_undefined_execute_command_raises_exception

--- a/test/unit/test_deprecation_logger.rb
+++ b/test/unit/test_deprecation_logger.rb
@@ -20,7 +20,7 @@ module SSHKit
 
       assert_equal(2, actual_lines.size)
       assert_equal "[Deprecated] Some message\n", actual_lines[0]
-      assert_match %r{    \(Called from .*sshkit/test/unit/test_deprecation_logger.rb:#{line_number}:in `generate_warning'\)\n}, actual_lines[1]
+      assert_match %r{    \(Called from .*sshkit/test/unit/test_deprecation_logger.rb:#{line_number}:in .*generate_warning.\)\n}, actual_lines[1]
     end
 
     def test_handles_nil_output


### PR DESCRIPTION
Ruby head has apparently changed the formatting of back traces slightly. This PR updates the regular expressions that we use for asserting back traces, so that they work with the new format.

Fixes CI failures on master.