### PR TITLE
Avoid calling closed? outside of synchronize block

### DIFF
--- a/lib/sshkit/backends/connection_pool/cache.rb
+++ b/lib/sshkit/backends/connection_pool/cache.rb
@@ -36,7 +36,7 @@ class SSHKit::Backend::ConnectionPool::Cache
   def evict
     # Peek at the first connection to see if it is still fresh. If so, we can
     # return right away without needing to use `synchronize`.
-    first_expires_at, first_conn = connections.first
+    first_expires_at, _first_conn = connections.first
     return if (first_expires_at.nil? || fresh?(first_expires_at))
 
     connections.synchronize do

--- a/lib/sshkit/backends/connection_pool/cache.rb
+++ b/lib/sshkit/backends/connection_pool/cache.rb
@@ -37,7 +37,7 @@ class SSHKit::Backend::ConnectionPool::Cache
     # Peek at the first connection to see if it is still fresh. If so, we can
     # return right away without needing to use `synchronize`.
     first_expires_at, first_conn = connections.first
-    return if (first_expires_at.nil? || fresh?(first_expires_at)) && !closed?(first_conn)
+    return if (first_expires_at.nil? || fresh?(first_expires_at))
 
     connections.synchronize do
       fresh, stale = connections.partition do |expires_at, conn|


### PR DESCRIPTION
`closed?` calls `process` on the connection which is not safe because we have not synchronised the connection pool. Another thread might concurrently checkout the connection and start sending commands as well.