### PR TITLE
Drop `mutex_m` dependency

### DIFF
--- a/lib/sshkit/backends/netssh.rb
+++ b/lib/sshkit/backends/netssh.rb
@@ -1,6 +1,5 @@
 require 'English'
 require 'strscan'
-require 'mutex_m'
 require 'net/ssh'
 
 module Net

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |gem|
   gem.version       = SSHKit::VERSION
 
   gem.add_runtime_dependency('base64') if RUBY_VERSION >= "2.4"
-  gem.add_runtime_dependency('mutex_m')
   gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')
   gem.add_runtime_dependency('net-sftp', '>= 2.1.2')


### PR DESCRIPTION
Just use a plain mutex instead since only `synchronize` is used.