### PR TITLE
Improve auto-generation of release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: "$NEXT_PATCH_VERSION"
-tag-template: "v$NEXT_PATCH_VERSION"
+name-template: "$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: "⚠️ Breaking Changes"
     label: "⚠️ Breaking"
@@ -11,7 +11,15 @@ categories:
     label: "📚 Docs"
   - title: "🏠 Housekeeping"
     label: "🏠 Housekeeping"
+version-resolver:
+  minor:
+    labels:
+      - "⚠️ Breaking"
+      - "✨ Feature"
+  default: patch
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
 no-changes-template: "- No changes"
 template: |
   $CHANGES
+
+  **Full Changelog:** https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION


### PR DESCRIPTION
This brings SSHKit's configuration of [Release Drafter](https://github.com/release-drafter/release-drafter) up to date with what is used [in Capistrano](https://github.com/capistrano/capistrano/blob/c30610d6a0ccb1d62fcc8a3c4b59b6d71989ed65/.github/release-drafter.yml).

- Automatically choose next version number based on PR labels
- Include "full changelog" link in generated release notes
