### PR TITLE
Add ostruct dependency to fix warning on Ruby 3.3.5+

### DIFF
--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')
   gem.add_runtime_dependency('net-sftp', '>= 2.1.2')
-  gem.add_runtime_dependency('ostruct')
+  gem.add_runtime_dependency('ostruct') if RUBY_VERSION >= "2.5"
 
   gem.add_development_dependency('danger')
   gem.add_development_dependency('minitest', '>= 5.0.0')

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')
   gem.add_runtime_dependency('net-sftp', '>= 2.1.2')
+  gem.add_runtime_dependency('ostruct')
 
   gem.add_development_dependency('danger')
   gem.add_development_dependency('minitest', '>= 5.0.0')


### PR DESCRIPTION
Fixes the following warning on Ruby 3.3.5+ and Ruby 3.4:

> sshkit-1.23.0/lib/sshkit.rb:29: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.

Closes #541