### PR TITLE
Add `logger` runtime dependency to fix warning on Ruby 3.4

### DIFF
--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_runtime_dependency('base64')
+  gem.add_runtime_dependency('logger')
   gem.add_runtime_dependency('net-ssh',  '>= 2.8.0')
   gem.add_runtime_dependency('net-scp',  '>= 1.1.2')
   gem.add_runtime_dependency('net-sftp', '>= 2.1.2')


### PR DESCRIPTION
Using sshkit on Ruby 3.4 causes the following warning to be printed:

> warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
> You can add logger to your Gemfile or gemspec to silence this warning.

To avoid this warning, and to allow sshkit to work on Ruby 3.5+, this commit adds the `logger` gem as a runtime dependency to sshkit.