### PR TITLE
Remove version pin for `rainbow` dev dependency

### DIFF
--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('danger')
   gem.add_development_dependency('minitest', '>= 5.0.0')
   gem.add_development_dependency('minitest-reporters')
-  gem.add_development_dependency('rainbow', '~> 2.2.2')
   gem.add_development_dependency('rake')
   gem.add_development_dependency('rubocop', "~> 0.52.0")
   gem.add_development_dependency('mocha')


### PR DESCRIPTION
The `rainbow` gem is a dependency of rubocop, which we use as a development dependency on this project. Previously, we were explicitly declaring rainbow as a dependency so that we could pin it at a specific version. This was done to ensure the development gems could be installed on old versions of Ruby in CI (see f57347a).

Now that sshkit no longer supports Ruby < 2.5, this workaround is no longer needed. This commit removes the explicit rainbow dev dependency.