### PR TITLE
Allow to use config object per running

### DIFF
--- a/lib/sshkit/backends/local.rb
+++ b/lib/sshkit/backends/local.rb
@@ -6,8 +6,8 @@ module SSHKit
 
     class Local < Abstract
 
-      def initialize(_ = nil, &block)
-        super(Host.new(:local), &block)
+      def initialize(**options, &block)
+        super(Host.new(:local), **options, &block)
       end
 
       def upload!(local, remote, options = {})

--- a/lib/sshkit/configuration.rb
+++ b/lib/sshkit/configuration.rb
@@ -35,8 +35,8 @@ module SSHKit
 
     def default_runner_config=(config_hash)
       config = config_hash.dup
-      SSHKit.config.default_runner = config.delete(:in) if config[:in]
-      @default_runner_config = config.merge(in: SSHKit.config.default_runner)
+      @default_runner = config.delete(:in) if config[:in]
+      @default_runner_config = config.merge(in: @default_runner)
     end
 
     def backend
@@ -71,9 +71,9 @@ module SSHKit
     #
     #   config.output = SSHKit::Formatter::Pretty.new($stdout)
     #
-    def use_format(formatter, *args)
+    def use_format(formatter, options = {})
       klass = formatter.is_a?(Class) ? formatter : formatter_class(formatter)
-      self.output = klass.new($stdout, *args)
+      self.output = klass.new($stdout, options.merge(config: self))
     end
 
     def command_map

--- a/lib/sshkit/coordinator.rb
+++ b/lib/sshkit/coordinator.rb
@@ -9,26 +9,23 @@ module SSHKit
       @hosts = @raw_hosts.any? ? resolve_hosts : []
     end
 
-    def each(options={}, &block)
-      if hosts
-        options = default_options.merge(options)
+    def each(**options, &block)
+      options = (options[:config] || SSHKit.config).default_runner_config.merge(options)
+      
+      if hosts  
         case options[:in]
         when :parallel then Runner::Parallel
         when :sequence then Runner::Sequential
         when :groups   then Runner::Group
         else
           options[:in]
-        end.new(hosts, options, &block).execute
+        end.new(hosts, **options, &block).execute
       else
-        Runner::Null.new(hosts, options, &block).execute
+        Runner::Null.new(hosts, **options, &block).execute
       end
     end
 
     private
-
-    def default_options
-      SSHKit.config.default_runner_config
-    end
 
     def resolve_hosts
       @raw_hosts.collect { |rh| rh.is_a?(Host) ? rh : Host.new(rh) }.uniq

--- a/lib/sshkit/dsl.rb
+++ b/lib/sshkit/dsl.rb
@@ -2,12 +2,12 @@ module SSHKit
 
   module DSL
 
-    def on(hosts, options={}, &block)
-      Coordinator.new(hosts).each(options, &block)
+    def on(hosts, **options, &block)
+      Coordinator.new(hosts).each(**options, &block)
     end
 
-    def run_locally(&block)
-      Backend::Local.new(&block).run
+    def run_locally(**options, &block)
+      Backend::Local.new(**options, &block).run
     end
 
   end

--- a/lib/sshkit/formatters/abstract.rb
+++ b/lib/sshkit/formatters/abstract.rb
@@ -7,7 +7,7 @@ module SSHKit
     class Abstract
 
       extend Forwardable
-      attr_reader :original_output, :options
+      attr_reader :original_output, :options, :config
       def_delegators :@original_output, :read, :rewind
       def_delegators :@color, :colorize
 
@@ -15,6 +15,7 @@ module SSHKit
         @original_output = output
         @options = options
         @color = SSHKit::Color.new(output)
+        @config = options[:config] || SSHKit.config
       end
 
       %w(fatal error warn info debug).each do |level|

--- a/lib/sshkit/formatters/pretty.rb
+++ b/lib/sshkit/formatters/pretty.rb
@@ -50,7 +50,7 @@ module SSHKit
       private
 
       def write_message(verbosity, message, uuid=nil)
-        original_output << "#{format_message(verbosity, message, uuid)}\n" if verbosity >= SSHKit.config.output_verbosity
+        original_output << "#{format_message(verbosity, message, uuid)}\n" if verbosity >= config.output_verbosity
       end
 
     end

--- a/lib/sshkit/mapping_interaction_handler.rb
+++ b/lib/sshkit/mapping_interaction_handler.rb
@@ -2,8 +2,9 @@ module SSHKit
 
   class MappingInteractionHandler
 
-    def initialize(mapping, log_level=nil)
+    def initialize(mapping, log_level=nil, **options)
       @log_level = log_level
+      @config = options[:config] || SSHKit.config
       @mapping_proc = \
         case mapping
         when Hash
@@ -40,7 +41,7 @@ module SSHKit
     private
 
     def log(message)
-      SSHKit.config.output.send(@log_level, message) unless @log_level.nil?
+      @config.output.send(@log_level, message) unless @log_level.nil?
     end
 
   end

--- a/lib/sshkit/runners/abstract.rb
+++ b/lib/sshkit/runners/abstract.rb
@@ -4,21 +4,22 @@ module SSHKit
 
     class Abstract
 
-      attr_reader :hosts, :options, :block
+      attr_reader :hosts, :options, :block, :config
 
-      def initialize(hosts, options = nil, &block)
+      def initialize(hosts, **options, &block)
         @hosts       = Array(hosts)
-        @options     = options || {}
+        @options     = options
         @block       = block
+        @config      = options[:config] || SSHKit.config
       end
 
       private
 
       def backend(host, &block)
         if host.local?
-          SSHKit::Backend::Local.new(&block)
+          SSHKit::Backend::Local.new(config: config, &block)
         else
-          SSHKit.config.backend.new(host, &block)
+          config.backend.new(host, config: config, &block)
         end
       end
 

--- a/lib/sshkit/runners/group.rb
+++ b/lib/sshkit/runners/group.rb
@@ -5,8 +5,8 @@ module SSHKit
     class Group < Sequential
       attr_accessor :group_size
 
-      def initialize(hosts, options = nil, &block)
-        super(hosts, options, &block)
+      def initialize(hosts, **options, &block)
+        super(hosts, **options, &block)
         @group_size = @options[:limit] || 2
       end
 

--- a/lib/sshkit/runners/sequential.rb
+++ b/lib/sshkit/runners/sequential.rb
@@ -5,8 +5,8 @@ module SSHKit
     class Sequential < Abstract
       attr_accessor :wait_interval
 
-      def initialize(hosts, options = nil, &block)
-        super(hosts, options, &block)
+      def initialize(hosts, **options, &block)
+        super(hosts, **options, &block)
         @wait_interval = @options[:wait] || 2
       end
 

--- a/test/unit/backends/test_abstract.rb
+++ b/test/unit/backends/test_abstract.rb
@@ -35,7 +35,7 @@ module SSHKit
 
         assert_equal '/usr/bin/env ls -l /some/directory', backend.executed_command.to_command
         assert_equal(
-          {:raise_on_non_zero_exit=>true, :run_in_background=>false, :in=>nil, :env=>nil, :host=>ExampleBackend.example_host, :user=>nil, :group=>nil},
+          {:raise_on_non_zero_exit=>true, :run_in_background=>false, :in=>nil, :env=>nil, :host=>ExampleBackend.example_host, :user=>nil, :group=>nil, :config=>SSHKit.config},
           backend.executed_command.options
         )
       end

--- a/test/unit/test_configuration.rb
+++ b/test/unit/test_configuration.rb
@@ -109,7 +109,7 @@ module SSHKit
       formatter = SSHKit.config.output
       assert_instance_of(TestFormatter, formatter)
       assert_equal($stdout, formatter.output)
-      assert_equal({ :color => false }, formatter.options)
+      assert_equal({ :color => false, :config => SSHKit.config }, formatter.options)
     end
 
     class TestFormatter

--- a/test/unit/test_mapping_interaction_handler.rb
+++ b/test/unit/test_mapping_interaction_handler.rb
@@ -14,13 +14,13 @@ module SSHKit
     end
 
     def test_calls_send_data_with_mapped_input_when_stdout_matches
-      handler = MappingInteractionHandler.new('Server output' => "some input\n")
+      handler = MappingInteractionHandler.new({'Server output' => "some input\n"})
       channel.expects(:send_data).with("some input\n")
       handler.on_data(nil, :stdout, 'Server output', channel)
     end
 
     def test_calls_send_data_with_mapped_input_when_stderr_matches
-      handler = MappingInteractionHandler.new('Server output' => "some input\n")
+      handler = MappingInteractionHandler.new({'Server output' => "some input\n"})
       channel.expects(:send_data).with("some input\n")
       handler.on_data(nil, :stderr, 'Server output', channel)
     end


### PR DESCRIPTION
This PR allows you to configure SSHKit in a multithreaded environment per run. Currently, this isn't possible because much of the configuration is set in a global class variable under `SSHKit.config`.

While SSHKit is initially intended to run when using Capistrano or Kamal from the command line, where a global configuration is sufficient, if you want to use it to run commands via SSH from a Rails job and you want to configure things like the output log, the default environment, or the command map differently for each run, things get complicated.

Example

```ruby
require 'sshkit'
require 'sshkit/dsl'
include SSHKit::DSL

config = SSHKit::Configuration.new.tap do |c|
  c.output = MyLogger.new
end

on "example.com", in: :sequence, config: config do |host|
  # ...
end
```