### PR TITLE
Add Ruby 4 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "head"]
+        ruby:
+          [
+            "2.5",
+            "2.6",
+            "2.7",
+            "3.0",
+            "3.1",
+            "3.2",
+            "3.3",
+            "3.4",
+            "4.0",
+            "head",
+          ]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby

--- a/sshkit.gemspec
+++ b/sshkit.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency('net-sftp', '>= 2.1.2')
   gem.add_runtime_dependency('ostruct')
 
+  gem.add_development_dependency('benchmark')
   gem.add_development_dependency('danger')
   gem.add_development_dependency('minitest', '>= 5.0.0')
   gem.add_development_dependency('minitest-reporters')


### PR DESCRIPTION
Ruby 4.0 was released on Dec 25, 2025. This PR adds it to our CI matrix.

Since 4.0 no longer includes the `benchmark` gem, I also added it as an explicit development dependency to fix the following error:

> 'Kernel.require': cannot load such file -- benchmark (LoadError)